### PR TITLE
SinkIsland Enhancements

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -285,6 +285,7 @@
   },
   "SinkIslandCheck": {
     "tree.size": 50,
+    "minimum.highway.type": "SERVICE",
     "challenge": {
       "description": "Tasks that identify islands of roads where it is impossible to get out. The simplest is a one-way that dead-ends; that would be a one-edge island.",
       "blurb": "Identify islands of roads.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -285,7 +285,7 @@
   },
   "SinkIslandCheck": {
     "tree.size": 50,
-    "minimum.highway.type": "SERVICE",
+    "minimum.highway.type": "service",
     "challenge": {
       "description": "Tasks that identify islands of roads where it is impossible to get out. The simplest is a one-way that dead-ends; that would be a one-edge island.",
       "blurb": "Identify islands of roads.",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -100,7 +100,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
         {
             // If this edge has certain characteristics, we can be sure that we don't want to
             // flag it.
-            if (this.doNotFlagThisEdge(candidate))
+            if (this.edgeCharacteristicsToIgnore(candidate))
             {
                 emptyFlag = true;
                 break;
@@ -213,7 +213,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
      * @return {@code true} if the edge is already flagged, has an amenity type we want to exclude,
      *         or ends in a boundary node {@code false} otherwise
      */
-    private boolean doNotFlagThisEdge(final Edge edge)
+    private boolean edgeCharacteristicsToIgnore(final Edge edge)
     {
         // If the edge has already been flagged by another process then we can break out of the
         // loop and assume that whether the check was a flag or not was handled by the other process

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -101,7 +101,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
         while (candidate != null)
         {
             // If this edge has certain characteristics, we can be sure that we don't want to
-            // flag this node.
+            // flag it.
             if (this.shouldQuitNow(candidate))
             {
                 emptyFlag = true;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -100,7 +100,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
         {
             // If this edge has certain characteristics, we can be sure that we don't want to
             // flag it.
-            if (this.shouldQuitNow(candidate))
+            if (this.doNotFlagThisEdge(candidate))
             {
                 emptyFlag = true;
                 break;
@@ -213,7 +213,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
      * @return {@code true} if the edge is already flagged, has an amenity type we want to exclude,
      *         or ends in a boundary node {@code false} otherwise
      */
-    private boolean shouldQuitNow(final Edge edge)
+    private boolean doNotFlagThisEdge(final Edge edge)
     {
         // If the edge has already been flagged by another process then we can break out of the
         // loop and assume that whether the check was a flag or not was handled by the other process

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -79,7 +79,7 @@ public class SinkIslandCheckTest
     @Test
     public void testInvalidEdges()
     {
-        this.verifier.actual(this.setup.getServiceSinkIsland(),
+        this.verifier.actual(this.setup.getInvalidEdges(),
                 new SinkIslandCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -84,4 +84,13 @@ public class SinkIslandCheckTest
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
+
+    @Test
+    public void testHighwayImportanceConfiguration()
+    {
+        this.verifier.actual(this.setup.getServiceSinkIsland(),
+                new SinkIslandCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"SinkIslandCheck\": {\"tree.size\": 3, \"highway.importance.minimum\": \"RESIDENTIAL\"}}")));
+        this.verifier.verifyEmpty();
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -90,7 +90,7 @@ public class SinkIslandCheckTest
     {
         this.verifier.actual(this.setup.getServiceSinkIsland(),
                 new SinkIslandCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"SinkIslandCheck\": {\"tree.size\": 3, \"highway.importance.minimum\": \"RESIDENTIAL\"}}")));
+                        "{\"SinkIslandCheck\": {\"tree.size\": 3, \"minimum.highway.type\": \"RESIDENTIAL\"}}")));
         this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -9,6 +9,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 /**
  * @author matthieun
  * @author gpogulsky
+ * @author nachtm
  */
 public class SinkIslandCheckTest
 {
@@ -42,4 +43,45 @@ public class SinkIslandCheckTest
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
+    @Test
+    public void testTwoEdgesWithAmenity()
+    {
+        this.verifier.actual(this.setup.getTwoEdgesWithAmenityAtlas(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testTrackSinkIsland()
+    {
+        this.verifier.actual(this.setup.getTrackSinkIsland(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testTrackAndPrimarySinkIsland()
+    {
+        this.verifier.actual(this.setup.getTrackAndPrimarySinkIsland(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testServiceSinkIsland()
+    {
+        this.verifier.actual(this.setup.getServiceSinkIsland(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\":3}")));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdges()
+    {
+        this.verifier.actual(this.setup.getServiceSinkIsland(),
+                new SinkIslandCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -11,6 +11,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
  * {@link SinkIslandCheck} test data
  *
  * @author gpogulsky
+ * @author nachtm
  */
 public class SinkIslandCheckTestRule extends CoreTestRule
 {
@@ -66,6 +67,65 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                     @Loc(value = TEST_7) }, tags = { "highway=primary", "oneway=yes" }) })
     private Atlas singleEdgeWithAmenityAtlas;
 
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)),
+            @Node(coordinates = @Loc(value = TEST_3), tags = { "amenity=parking_space" }) },
+
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=primary" }) })
+    private Atlas twoEdgesWithAmenityAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=track" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=track" }) })
+    private Atlas trackSinkIsland;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=track" }) })
+    private Atlas trackAndHighwaySinkIsland;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=service" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=service" }) })
+    private Atlas serviceSinkIsland;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=service", "aeroway=taxiway" }),
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=service", "route=ferry" }),
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=footpath" }),
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=service", "area=yes" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=service" }),
+                    @Edge(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_1) }, tags = {
+                            "highway=service" }), })
+    private Atlas invalidEdges;
+
     public Atlas getSingleEdgeAtlas()
     {
         return this.singleEdgeAtlas;
@@ -79,5 +139,30 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     public Atlas getSingleEdgeWithAmenityAtlas()
     {
         return this.singleEdgeWithAmenityAtlas;
+    }
+
+    public Atlas getTwoEdgesWithAmenityAtlas()
+    {
+        return this.twoEdgesWithAmenityAtlas;
+    }
+
+    public Atlas getTrackSinkIsland()
+    {
+        return this.trackSinkIsland;
+    }
+
+    public Atlas getTrackAndPrimarySinkIsland()
+    {
+        return this.trackAndHighwaySinkIsland;
+    }
+
+    public Atlas getServiceSinkIsland()
+    {
+        return this.serviceSinkIsland;
+    }
+
+    public Atlas getInvalidEdges()
+    {
+        return this.invalidEdges;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -70,7 +70,6 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
             @Node(coordinates = @Loc(value = TEST_2)),
             @Node(coordinates = @Loc(value = TEST_3), tags = { "amenity=parking_space" }) },
-
             edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
                             "highway=primary" }),
@@ -80,7 +79,6 @@ public class SinkIslandCheckTestRule extends CoreTestRule
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
             @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)) },
-
             edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
                             "highway=track" }),
@@ -90,7 +88,6 @@ public class SinkIslandCheckTestRule extends CoreTestRule
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
             @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)) },
-
             edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
                             "highway=primary" }),
@@ -100,7 +97,6 @@ public class SinkIslandCheckTestRule extends CoreTestRule
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
             @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)) },
-
             edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
                             "highway=service" }),
@@ -110,7 +106,6 @@ public class SinkIslandCheckTestRule extends CoreTestRule
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
             @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)) },
-
             edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
                             "highway=service", "aeroway=taxiway" }),


### PR DESCRIPTION
This PR strives to make a couple of improvements to SinkIslandCheck:

- There is now a configurable `highway.importance.minimum` value. `validCheckForObject` will return false for any edges with highway tags less important than this value.
- There is now a distinction between edges that should be ignored and edges that should cause the check to skip this chunk of the network. Included in that first category are `aeroway=TAXIWAY`, `aeroway=RUNWAY`, edges that are not car-navigable, ferries, and edges that are tagged as areas. The second category includes synthetic boundary nodes and a variety of `amenity=parking` tags.

The logic behind this distinction is this: edges in the second category were originally in the first category. Simply ignoring these edges leads to confusing flags when, for example, the road leading to an edge with a parking tag is flagged, but the last node in the chain is not. For an example of this, see [this way](https://www.openstreetmap.org/way/301846131), [this way](https://www.openstreetmap.org/way/301846129), and [this node](https://www.openstreetmap.org/node/3059979614). Additionally, distinguishing between a valid parking garage (potentially with an exit on the other side of a building) and a sink island ending in a parking node was determined to be complicated enough to be outside the scope of this check. So, the second category is clearly necessary. 

At the same time, we don't want to miss out on sink islands just because, for example, there is a footpath connected to the road at some point. So, we also need the first category.

I added a couple of unit tests to confirm this behavior, and they are currently passing.