### PR TITLE
Spiky buildings

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -13,7 +13,8 @@
     }
   },
   "SpikyBuildingCheck": {
-    "angle.minimum": 15,
+    "angle.spiky.maximum": 15,
+    "angle.circular.maximum": 25,
     "sides.minimum": 3
   },
   "OrphanNodeCheck": {

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -13,11 +13,12 @@
     }
   },
   "SpikyBuildingCheck": {
-    "angle.circular.total.minimum": 10,
-    "sides.circular.minimum": 4,
-    "angle.spiky.maximum": 15,
-    "angle.circular.maximum": 25,
-    "sides.minimum": 3
+    "spiky.angle.maximum": 15,
+    "curves": {
+      "angle.maximum": 25,
+      "angle.total.minimum": 10,
+      "points.minimum": 4
+    }
   },
   "OrphanNodeCheck": {
 

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -13,10 +13,12 @@
     }
   },
   "SpikyBuildingCheck": {
-    "spiky.angle.maximum": 15,
+    "spiky.angle.maximum": 15.0,
     "curve": {
-      "angle.maximum": 25,
-      "angle.total.minimum": 10,
+      "degrees": {
+        "maximum.single_heading_change": 25.0,
+        "minimum.total_heading_change": 10.0
+      },
       "points.minimum": 4
     },
     "challenge": {

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -12,6 +12,8 @@
       "minimum": 50.0
     }
   },
+  "SpikyBuildingCheck": {
+  },
   "OrphanNodeCheck": {
 
   },

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -13,6 +13,8 @@
     }
   },
   "SpikyBuildingCheck": {
+    "angle.circular.total.minimum": 10,
+    "sides.circular.minimum": 4,
     "angle.spiky.maximum": 15,
     "angle.circular.maximum": 25,
     "sides.minimum": 3

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -13,6 +13,8 @@
     }
   },
   "SpikyBuildingCheck": {
+    "angle.minimum": 15,
+    "sides.minimum": 3
   },
   "OrphanNodeCheck": {
 

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -18,6 +18,13 @@
       "angle.maximum": 25,
       "angle.total.minimum": 10,
       "points.minimum": 4
+    },
+    "challenge": {
+      "description": "Find poorly digitized buildings with sharp angles in their geometry",
+      "blurb": "Fix buildings with spiky geometry",
+      "instruction": "Open your favorite editor and validate that the buildings are mapped correctly",
+      "difficulty": "NORMAL",
+      "tags":"building"
     }
   },
   "OrphanNodeCheck": {

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -14,7 +14,7 @@
   },
   "SpikyBuildingCheck": {
     "spiky.angle.maximum": 15,
-    "curves": {
+    "curve": {
       "angle.maximum": 25,
       "angle.total.minimum": 10,
       "points.minimum": 4

--- a/docs/checks/spikyBuildingCheck.md
+++ b/docs/checks/spikyBuildingCheck.md
@@ -33,5 +33,29 @@ digitization and should not be flagged.
 
 #### Code Review
 
+###### Curves
+Perfectly identifying curved sections of a building's geometry is not possible, especially given the
+wide variety of mapping techniques across the world. However, it is possible to use heuristics to
+get pretty close. This section will briefly walk through the algorithm used by `SpikyBuildingCheck`
+to detect curves.
+
+The first thing to note is that throughout the code, points are stored as the two surrounding segments.
+So, for a triangle with points ABC and lines (AB, BC, and CA), we store the point B as <AB, BC>. This
+way, we have a little extra context needed later on down the line.
+
+The entry point into this algorithm is `getCurvedLocations`, but we'll start in `getPotentiallyCircularPoints`,
+which grabs all points in a polygon where the change in heading between the previous and following
+segments is less than some threshold. Once we have that list, we want to combine consecutive points
+into a potentially circular segment. We do this in `summarizedCurvedSections`, which takes in an ordered
+list of points in a polygon, and finds the start and end of each segment of consecutive points
+(points that share a segment between them). It returns the segment before the start point, the segment
+after the end point, and the total number of points present in the section. From there, `getCurvedLocations`
+filters out all the summarized curved sections that are either too short, or the difference in headings
+between the first and last segment in the section is too small. Finally, `sectionsToLocations` takes
+all of the curvedLocations and converts them from the metadata tuple with length, start and end, back
+to a list of locations. By taking all the sections at once, it is able to complete the entire conversion
+in a single pass of the list of all segments, since both are in the same order.
+
+###### More Information
 For more information, see the source code in 
 [SpikyBuildingCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java).

--- a/docs/checks/spikyBuildingCheck.md
+++ b/docs/checks/spikyBuildingCheck.md
@@ -1,0 +1,37 @@
+# SpikyBuildingCheck
+
+The purpose of this check is to identify buildings with extremely sharp angles in their geometry. 
+These angles, or “spikes” are formed by two or more poly-lines and a peak node. These spikes are often 
+hard to visually inspect as the poly-lines that create them can be very small. Spikes in building 
+geometry are almost always errors and should be corrected. They can be inadvertently created in the 
+data creation process by incorrectly closing a poly-line to create a polygon.
+
+The original issue was raised in an [OpenStreetMap Help forum](https://help.openstreetmap.org/questions/66104/is-there-a-way-to-detect-very-sharp-angles-of-buildings). 
+OSM user “sanser” included [a paper](https://drive.google.com/file/d/1MaLdnSnc454xKjn3eL95vDQKeoIW8zGU/view)
+with their answer which described the methodology for identifying and correcting “spiky buildings” in the UK.
+
+This check flags all Atlas objects for which the following criteria are true:
+ * The object is a building or a building part
+ * The angle created by the intersection of any two line segments within the building's geometry 
+ should be less than 15˚ (configurable value).
+ * An angle less than 15˚ should not be flagged if it occurs at the beginning or end of a curve 
+ within the building's geometry. There should be three configurable values that control this behavior: 
+ minimum number of points needed to comprise a curve, angle threshold between a curve and a non-curve, 
+ and minimum total change in heading for the curve.
+
+#### Live Examples
+
+The way [34550963](https://www.openstreetmap.org/way/34550963) is tagged as a building, and has a 
+spiky protrusion less than 15 degrees that was likely accidental.
+
+The way [60485431](https://www.openstreetmap.org/way/60485431) is tagged as a building, but looks like it was
+poorly digitized when compared to satellite imagery. 
+
+The way [503863867](https://www.openstreetmap.org/way/503863867) is tagged as a building and has an
+angle less than 15 degrees, but it is part of an intentionally mapped circle. This is a correct 
+digitization and should not be flagged.
+
+#### Code Review
+
+For more information, see the source code in 
+[SpikyBuildingCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java).

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -66,16 +66,16 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     public SpikyBuildingCheck(final Configuration configuration)
     {
         super(configuration);
-        this.headingThreshold = this.configurationValue(configuration, "angle.spiky.maximum",
+        this.headingThreshold = this.configurationValue(configuration, "spiky.angle.maximum",
                 DEFAULT_MIN_HEADING_THRESHOLD, threshold -> Angle.degrees((double) threshold));
         this.circularAngleThreshold = this.configurationValue(configuration,
-                "angle.circular.maximum", DEFAULT_CIRCULAR_ANGLE_THRESHOLD,
+                "curves.angle.maximum", DEFAULT_CIRCULAR_ANGLE_THRESHOLD,
                 threshold -> Angle.degrees((double) threshold));
         this.minimumTotalCircularAngleThreshold = this.configurationValue(configuration,
-                "angle.circular.total.minimum", DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD,
+                "curves.angle.total.minimum", DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD,
                 threshold -> Angle.degrees((double) threshold));
         this.minimumCircularPointsInCurve = this.configurationValue(configuration,
-                "sides.circular.minimum", DEFAULT_MINIMUM_CIRCULAR_LINE_SEGMENTS);
+                "curves.points.minimum", DEFAULT_MINIMUM_CIRCULAR_LINE_SEGMENTS);
     }
 
     @Override
@@ -134,7 +134,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
         else if (((Relation) object).isMultiPolygon())
         {
             return ((Relation) object).members().stream().map(this::toPolygon).flatMap(
-                    optPoly -> optPoly.isPresent() ? Stream.of(optPoly.get()) : Stream.empty());
+                    optPoly -> optPoly.map(Stream::of).orElse(Stream.empty()));
         }
         logger.warn("Returning empty stream");
         return Stream.empty();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -62,11 +62,12 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
         super(configuration);
         this.headingThreshold = this.configurationValue(configuration, "spiky.angle.maximum",
                 DEFAULT_MIN_HEADING_THRESHOLD, Angle::degrees);
-        this.circularAngleThreshold = this.configurationValue(configuration, "curve.degrees.maximum.single_heading_change",
-                DEFAULT_CIRCULAR_ANGLE_THRESHOLD, Angle::degrees);
-        this.minimumTotalCircularAngleThreshold = this.configurationValue(configuration,
-                "curve.degrees.minimum.total_heading_change", DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD,
+        this.circularAngleThreshold = this.configurationValue(configuration,
+                "curve.degrees.maximum.single_heading_change", DEFAULT_CIRCULAR_ANGLE_THRESHOLD,
                 Angle::degrees);
+        this.minimumTotalCircularAngleThreshold = this.configurationValue(configuration,
+                "curve.degrees.minimum.total_heading_change",
+                DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD, Angle::degrees);
         this.minimumCircularPointsInCurve = this.configurationValue(configuration,
                 "curve.points.minimum", DEFAULT_MINIMUM_CIRCULAR_POINTS);
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -45,7 +45,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     private static final long DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD = 10;
     private static final long DEFAULT_MINIMUM_CIRCULAR_LINE_SEGMENTS = 4;
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections.singletonList(
-            "This building has the following angle measurements under the minimum allowed angle of {0}: {1}");
+            "There are sharp angles ({0} degrees, which is less than the threshold of {1} degrees) in this building's geometry. This may be a result of poor digitization.");
     private Angle headingThreshold;
     private Angle circularAngleThreshold;
     private Angle minimumTotalCircularAngleThreshold;
@@ -76,7 +76,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     {
         return (object instanceof Area
                 || (object instanceof Relation && ((Relation) object).isMultiPolygon()))
-                && (this.isBuildingOrPart(object));
+                && this.isBuildingOrPart(object);
     }
 
     /**
@@ -391,9 +391,11 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
                 .collect(Collectors.toList());
         if (!allSpikyAngles.isEmpty())
         {
-            final String instruction = this.getLocalizedInstruction(0, headingThreshold.toString(),
-                    allSpikyAngles.stream().map(Tuple::getFirst).map(Angle::toString)
-                            .collect(Collectors.joining(", ")));
+            final String instruction = this
+                    .getLocalizedInstruction(0,
+                            allSpikyAngles.stream().map(Tuple::getFirst).map(Angle::toString)
+                                    .collect(Collectors.joining(", ")),
+                            headingThreshold.toString());
             final List<Location> markers = allSpikyAngles.stream().map(Tuple::getSecond)
                     .collect(Collectors.toList());
             final CheckFlag flag;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -1,0 +1,155 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Heading;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Segment;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.tags.BuildingPartTag;
+import org.openstreetmap.atlas.tags.BuildingTag;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * First pass at a spikybuilding check.
+ *
+ * @author nachtm
+ */
+public class SpikyBuildingCheck extends BaseCheck<Long>
+{
+    private final Logger logger = LoggerFactory.getLogger(SpikyBuildingCheck.class);
+
+    private static final Heading HEADING_THRESHOLD_LOWER = Heading.degrees(15);
+    private static final Heading HEADING_THRESHOLD_UPPER = Heading.degrees(165);
+    private static final double COS_15 = 0.9659258262890682867497431997288973676339;
+
+    /**
+     * Default constructor
+     *
+     * @param configuration {@link Configuration} required to construct any Check
+     */
+    public SpikyBuildingCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    // TODO remove code duplication
+    @Override public boolean validCheckForObject(final AtlasObject object)
+    {
+        return (object instanceof Area
+                || (object instanceof Relation && ((Relation) object).isMultiPolygon()))
+                && (this.isBuildingOrPart(object) || this.isBuildingRelationMember(object));
+    }
+
+    private boolean isBuildingOrPart(final AtlasObject object)
+    {
+        return (BuildingTag.isBuilding(object)
+                && Validators.isNotOfType(object, BuildingTag.class, BuildingTag.ROOF))
+                || Validators.isNotOfType(object, BuildingPartTag.class, BuildingPartTag.NO);
+    }
+
+    private boolean isBuildingRelationMember(final AtlasObject object)
+    {
+        return object instanceof AtlasEntity && ((AtlasEntity) object).relations().stream()
+                .anyMatch(relation -> Validators.isOfType(relation, RelationTypeTag.class,
+                        RelationTypeTag.BUILDING)
+                        && relation.members().stream()
+                        .anyMatch(member -> member.getEntity().equals(object)
+                                && (member.getRole().equals("outline"))
+                                || member.getRole().equals("part")));
+    }
+    // end TODO code duplication
+
+    private Optional<Polygon> toPolygon(final RelationMember member)
+    {
+        if (member.getEntity().getType().equals(ItemType.AREA))
+        {
+            return Optional.of(((Area) member.getEntity()).asPolygon());
+        }
+        return Optional.empty();
+    }
+
+    private Stream<Polygon> getPolylines(final AtlasObject object)
+    {
+        if (object instanceof Area)
+        {
+            return Stream.of(((Area) object).asPolygon());
+        } else if (((Relation) object).isMultiPolygon())
+        {
+            return StreamSupport.stream(((Relation) object).members().spliterator(), false)
+                    .map(this::toPolygon)
+                    .flatMap(optPoly -> optPoly.isPresent() ? Stream.of(optPoly.get()) : Stream.empty());
+        }
+        logger.warn("Returning empty stream");
+        return Stream.empty();
+    }
+
+    private boolean hasSkinnyAngle(final Polygon polygon)
+    {
+        final List<Segment> segments = polygon.segments();
+        // comparing second segment to first
+        for(int i = 1; i < segments.size(); i++) {
+            if (isSkinnyAngle(segments.get(i-1), segments.get(i))) {
+                return true;
+            }
+        }
+        // compare last segment to first
+        return isSkinnyAngle(segments.get(segments.size() - 1), segments.get(0));
+    }
+
+    private boolean isSkinnyAngle(final Segment firstSegment, final Segment secondSegment)
+    {
+//        final Heading first = firstSegment.pointingNorth().heading().get();
+//        final Heading second = secondSegment.pointingNorth().heading().get();
+//        return first.difference(second).isLessThan(HEADING_THRESHOLD_LOWER)
+//                || first.difference(second).isGreaterThan(HEADING_THRESHOLD_UPPER);
+        return cosine(firstSegment.start(), firstSegment.end(), secondSegment.end()) > COS_15;
+    }
+
+    public static double dotProd(final Location start, final Location middle, final Location end)
+    {
+        return dm7Mult(start.getLatitude().asDm7(), middle.getLatitude().asDm7(), end.getLatitude().asDm7())
+                + dm7Mult(start.getLongitude().asDm7(), middle.getLongitude().asDm7(), end.getLongitude().asDm7());
+    }
+
+    private static long dm7Mult(final long start, final long middle, final long end)
+    {
+        return (start - middle) * (end - middle);
+    }
+
+    public static double distance(final Location start, final Location end)
+    {
+        return Math.sqrt(Math.pow(start.getLatitude().asDm7() - end.getLatitude().asDm7(), 2)
+                + Math.pow(start.getLongitude().asDm7() - end.getLongitude().asDm7(), 2));
+    }
+
+    public static double cosine(final Location start, final Location middle, final Location end)
+    {
+        return dotProd(start, middle, end) / (distance(start, middle) * distance(middle, end));
+    }
+
+    @Override protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Stream<Polygon> buildingPolylines = getPolylines(object);
+
+        if(buildingPolylines.anyMatch(this::hasSkinnyAngle)) {
+            return Optional.of(this.createFlag(object, "Spiky building here."));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -41,7 +41,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
 
     private static final long DEFAULT_MIN_HEADING_THRESHOLD = 15;
     private static final long DEFAULT_MIN_SIDES_NUMBER = 3;
-    private static final long DEFAULT_CIRCULAR_ANGLE_THRESHOLD = 5;
+    private static final long DEFAULT_CIRCULAR_ANGLE_THRESHOLD = 25;
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections.singletonList(
             "This building has the following angle measurements under the minimum allowed angle of {0}: {1}");
     private Angle headingThreshold;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -40,10 +40,10 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
  */
 public class SpikyBuildingCheck extends BaseCheck<Long>
 {
-    private static final long DEFAULT_MIN_HEADING_THRESHOLD = 15;
-    private static final long DEFAULT_CIRCULAR_ANGLE_THRESHOLD = 25;
-    private static final long DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD = 10;
-    private static final long DEFAULT_MINIMUM_CIRCULAR_LINE_SEGMENTS = 4;
+    private static final double DEFAULT_MIN_HEADING_THRESHOLD = 15;
+    private static final double DEFAULT_CIRCULAR_ANGLE_THRESHOLD = 25;
+    private static final double DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD = 10;
+    private static final long DEFAULT_MINIMUM_CIRCULAR_POINTS = 4;
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections.singletonList(
             "There are sharp angles ({0} degrees, which is less than the threshold of {1} degrees) in this building's geometry. This may be a result of poor digitization.");
     private Angle headingThreshold;
@@ -61,14 +61,14 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     {
         super(configuration);
         this.headingThreshold = this.configurationValue(configuration, "spiky.angle.maximum",
-                DEFAULT_MIN_HEADING_THRESHOLD, threshold -> Angle.degrees((double) threshold));
-        this.circularAngleThreshold = this.configurationValue(configuration, "curve.angle.maximum",
-                DEFAULT_CIRCULAR_ANGLE_THRESHOLD, threshold -> Angle.degrees((double) threshold));
+                DEFAULT_MIN_HEADING_THRESHOLD, Angle::degrees);
+        this.circularAngleThreshold = this.configurationValue(configuration, "curve.degrees.maximum.single_heading_change",
+                DEFAULT_CIRCULAR_ANGLE_THRESHOLD, Angle::degrees);
         this.minimumTotalCircularAngleThreshold = this.configurationValue(configuration,
-                "curve.angle.total.minimum", DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD,
-                threshold -> Angle.degrees((double) threshold));
+                "curve.degrees.minimum.total_heading_change", DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD,
+                Angle::degrees);
         this.minimumCircularPointsInCurve = this.configurationValue(configuration,
-                "curve.points.minimum", DEFAULT_MINIMUM_CIRCULAR_LINE_SEGMENTS);
+                "curve.points.minimum", DEFAULT_MINIMUM_CIRCULAR_POINTS);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -41,7 +41,6 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     private final Logger logger = LoggerFactory.getLogger(SpikyBuildingCheck.class);
 
     private static final long DEFAULT_MIN_HEADING_THRESHOLD = 15;
-    private static final long DEFAULT_MIN_SIDES_NUMBER = 3;
     private static final long DEFAULT_CIRCULAR_ANGLE_THRESHOLD = 25;
     private static final long DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD = 10;
     private static final long DEFAULT_MINIMUM_CIRCULAR_LINE_SEGMENTS = 4;
@@ -50,7 +49,6 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
             "This building has the following angle measurements under the minimum allowed angle of {0}: {1}");
     private Angle headingThreshold;
     private Angle circularAngleThreshold;
-    private long minSidesNumber;
     private Angle minimumTotalCircularAngleThreshold;
     private long minimumCircularLineSegments;
 
@@ -65,8 +63,6 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
         super(configuration);
         this.headingThreshold = this.configurationValue(configuration, "angle.spiky.maximum",
                 DEFAULT_MIN_HEADING_THRESHOLD, threshold -> Angle.degrees((double) threshold));
-        this.minSidesNumber = this.configurationValue(configuration, "sides.minimum",
-                DEFAULT_MIN_SIDES_NUMBER);
         this.circularAngleThreshold = this.configurationValue(configuration,
                 "angle.circular.maximum", DEFAULT_CIRCULAR_ANGLE_THRESHOLD,
                 threshold -> Angle.degrees((double) threshold));
@@ -80,7 +76,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return ((object instanceof Area && ((Area) object).asPolygon().size() > minSidesNumber)
+        return ((object instanceof Area)
                 || (object instanceof Relation && ((Relation) object).isMultiPolygon()))
                 && (this.isBuildingOrPart(object));
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
@@ -40,9 +41,11 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
 
     private static final long DEFAULT_MIN_HEADING_THRESHOLD = 15;
     private static final long DEFAULT_MIN_SIDES_NUMBER = 3;
+    private static final long DEFAULT_CIRCULAR_ANGLE_THRESHOLD = 5;
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections.singletonList(
             "This building has the following angle measurements under the minimum allowed angle of {0}: {1}");
     private Angle headingThreshold;
+    private Angle circularAngleThreshold;
     private long minSidesNumber;
 
     /**
@@ -54,10 +57,13 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     public SpikyBuildingCheck(final Configuration configuration)
     {
         super(configuration);
-        this.headingThreshold = this.configurationValue(configuration, "angle.minimum",
+        this.headingThreshold = this.configurationValue(configuration, "angle.spiky.maximum",
                 DEFAULT_MIN_HEADING_THRESHOLD, threshold -> Angle.degrees((double) threshold));
         this.minSidesNumber = this.configurationValue(configuration, "sides.minimum",
                 DEFAULT_MIN_SIDES_NUMBER);
+        this.circularAngleThreshold = this.configurationValue(configuration,
+                "angle.circular.maximum", DEFAULT_CIRCULAR_ANGLE_THRESHOLD,
+                threshold -> Angle.degrees((double) threshold));
     }
 
     @Override
@@ -98,27 +104,131 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
         return Stream.empty();
     }
 
+    private Set<Integer> getIndicesOfCircularSegments(final List<Segment> segments)
+    {
+        final List<Integer> indices = new ArrayList<>();
+        for (int i = 1; i < segments.size(); i++)
+        {
+            final Angle difference = getDifferenceBetween(segments.get(i - 1), segments.get(i));
+            if (difference.isLessThan(circularAngleThreshold))
+            {
+                indices.add(i);
+            }
+        }
+
+        final Angle difference = getDifferenceBetween(segments.get(segments.size() - 1),
+                segments.get(0));
+        if (difference.isLessThan(circularAngleThreshold))
+        {
+            indices.add(0, 0);
+        }
+        return convertStartsAndEndsToIndices(expandStartsAndEnds(
+                convertToStartAndEnds(indices, segments.size()), segments.size()), segments.size());
+    }
+
+    private List<Tuple<Integer, Integer>> convertToStartAndEnds(final List<Integer> indices,
+            final int size)
+    {
+        if (indices.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+
+        final List<Tuple<Integer, Integer>> startsAndEnds = new ArrayList<>();
+        int start = indices.get(0);
+        int previous = indices.get(0);
+        for (int currentIndex = 1; currentIndex < indices.size(); currentIndex++)
+        {
+            final int currentValue = indices.get(currentIndex);
+            // if not continuous, we're at the end
+            if (currentValue - previous > 1)
+            {
+                startsAndEnds.add(Tuple.createTuple(start, indices.get(currentIndex - 1)));
+                start = currentValue;
+            }
+            // if right after previous, we're in the middle. don't update anything extra
+
+            // update previous before advancing
+            previous = currentValue;
+        }
+
+        // add the tuple containing the last index
+        startsAndEnds.add(Tuple.createTuple(start, previous));
+
+        // we might need to clean up a circular segment that wraps around 0.
+        if (startsAndEnds.get(0).getFirst() == 0
+                && startsAndEnds.get(startsAndEnds.size() - 1).getSecond() == size - 1)
+        {
+            startsAndEnds.set(0,
+                    Tuple.createTuple(startsAndEnds.get(startsAndEnds.size() - 1).getFirst(),
+                            startsAndEnds.get(0).getSecond()));
+            startsAndEnds.remove(startsAndEnds.size() - 1);
+        }
+        return startsAndEnds;
+    }
+
+    private List<Tuple<Integer, Integer>> expandStartsAndEnds(
+            final List<Tuple<Integer, Integer>> startsAndEnds, final int size)
+    {
+        return startsAndEnds.stream()
+                .map(original -> Tuple.createTuple(Math.floorMod(original.getFirst() - 1, size),
+                        Math.floorMod(original.getSecond() + 1, size)))
+                .collect(Collectors.toList());
+    }
+
+    private Set<Integer> convertStartsAndEndsToIndices(
+            final List<Tuple<Integer, Integer>> startsAndEnds, final int size)
+    {
+        return startsAndEnds.stream().flatMap(startEnd ->
+        {
+            final int start = startEnd.getFirst();
+            final int end = startEnd.getSecond();
+            final IntStream valStream;
+            // normal case
+            if (start <= end)
+            {
+                valStream = IntStream.rangeClosed(start, end);
+            }
+            // wrap around
+            else
+            {
+                valStream = IntStream.concat(IntStream.range(start, size),
+                        IntStream.rangeClosed(0, end));
+            }
+            return valStream.boxed();
+        }).collect(Collectors.toSet());
+    }
+
     // this is almost exactly the same as polygon.anglesLessThanOrEqualTo, except we also need to
     // compare the angle between the last segment and the first segment.
     private List<Tuple<Angle, Location>> getSkinnyAngleLocations(final Polygon polygon)
     {
         final List<Tuple<Angle, Location>> results = new ArrayList<>();
         final List<Segment> segments = polygon.segments();
+        final Set<Integer> circleIndices = getIndicesOfCircularSegments(segments);
+
         // comparing segment to previous segment
         for (int i = 1; i < segments.size(); i++)
         {
-            final Angle difference = getDifferenceBetween(segments.get(i - 1), segments.get(i));
-            if (difference.isLessThan(headingThreshold))
+            if (!circleIndices.contains(i))
             {
-                results.add(Tuple.createTuple(difference, segments.get(i).start()));
+                final Angle difference = getDifferenceBetween(segments.get(i - 1),
+                        segments.get(i).reversed());
+                if (difference.isLessThan(headingThreshold))
+                {
+                    results.add(Tuple.createTuple(difference, segments.get(i).start()));
+                }
             }
         }
         // compare last segment to first
-        final Angle difference = getDifferenceBetween(segments.get(segments.size() - 1),
-                segments.get(0));
-        if (difference.isLessThan(headingThreshold))
+        if (!circleIndices.contains(0))
         {
-            results.add(Tuple.createTuple(difference, segments.get(0).start()));
+            final Angle difference = getDifferenceBetween(segments.get(segments.size() - 1),
+                    segments.get(0).reversed());
+            if (difference.isLessThan(headingThreshold))
+            {
+                results.add(Tuple.createTuple(difference, segments.get(0).start()));
+            }
         }
         return results;
 
@@ -128,7 +238,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     {
         // TODO resolve get() issues
         final Heading first = firstSegment.heading().get();
-        final Heading second = secondSegment.reversed().heading().get();
+        final Heading second = secondSegment.heading().get();
         return first.difference(second);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheck.java
@@ -62,19 +62,19 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
         super(configuration);
         this.headingThreshold = this.configurationValue(configuration, "spiky.angle.maximum",
                 DEFAULT_MIN_HEADING_THRESHOLD, threshold -> Angle.degrees((double) threshold));
-        this.circularAngleThreshold = this.configurationValue(configuration, "curves.angle.maximum",
+        this.circularAngleThreshold = this.configurationValue(configuration, "curve.angle.maximum",
                 DEFAULT_CIRCULAR_ANGLE_THRESHOLD, threshold -> Angle.degrees((double) threshold));
         this.minimumTotalCircularAngleThreshold = this.configurationValue(configuration,
-                "curves.angle.total.minimum", DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD,
+                "curve.angle.total.minimum", DEFAULT_MINIMUM_TOTAL_CIRCULAR_ANGLE_THRESHOLD,
                 threshold -> Angle.degrees((double) threshold));
         this.minimumCircularPointsInCurve = this.configurationValue(configuration,
-                "curves.points.minimum", DEFAULT_MINIMUM_CIRCULAR_LINE_SEGMENTS);
+                "curve.points.minimum", DEFAULT_MINIMUM_CIRCULAR_LINE_SEGMENTS);
     }
 
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return ((object instanceof Area)
+        return (object instanceof Area
                 || (object instanceof Relation && ((Relation) object).isMultiPolygon()))
                 && (this.isBuildingOrPart(object));
     }
@@ -148,7 +148,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
                 .filter(segment -> segment.getLeft() >= minimumCircularPointsInCurve)
                 // Changes heading by at least minimumTotalCircularAngleThreshold
                 .filter(segment -> this
-                        .getDifferenceBetween(segment.getMiddle(), segment.getRight(),
+                        .getDifferenceInHeadings(segment.getMiddle(), segment.getRight(),
                                 Angle.MINIMUM)
                         .isGreaterThanOrEqualTo(minimumTotalCircularAngleThreshold))
                 .collect(Collectors.toList());
@@ -168,7 +168,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
     private List<Tuple<Segment, Segment>> getPotentiallyCircularPoints(final List<Segment> segments)
     {
         return this.segmentPairsFrom(segments)
-                .filter(segmentTuple -> this.getDifferenceBetween(segmentTuple.getFirst(),
+                .filter(segmentTuple -> this.getDifferenceInHeadings(segmentTuple.getFirst(),
                         segmentTuple.getSecond(), Angle.MAXIMUM).isLessThan(circularAngleThreshold))
                 .collect(Collectors.toList());
     }
@@ -350,8 +350,8 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
         if (!curvedLocations.contains(afterAngle.end())
                 && !curvedLocations.contains(beforeAngle.start()))
         {
-            final Angle difference = this.getDifferenceBetween(beforeAngle, afterAngle.reversed(),
-                    Angle.MAXIMUM);
+            final Angle difference = this.getDifferenceInHeadings(beforeAngle,
+                    afterAngle.reversed(), Angle.MAXIMUM);
             if (difference.isLessThan(headingThreshold))
             {
                 return Optional.of(Tuple.createTuple(difference, afterAngle.start()));
@@ -374,7 +374,7 @@ public class SpikyBuildingCheck extends BaseCheck<Long>
      *         segment is a single point (same start and end nodes), or defaultAngle if either
      *         segment is a single point
      */
-    private Angle getDifferenceBetween(final Segment firstSegment, final Segment secondSegment,
+    private Angle getDifferenceInHeadings(final Segment firstSegment, final Segment secondSegment,
             final Angle defaultAngle)
     {
         return firstSegment.heading()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -44,6 +44,15 @@ public class SpikyBuildingCheckTest
                 ConfigurationResolver.emptyConfiguration()));
         verifier.verifyEmpty();
     }
+
+    // We should ignore edges with only three vertices
+    @Test
+    public void ignoresSpikyButSmall() {
+        verifier.actual(setup.getSpikyButSmall(), new SpikyBuildingCheck(
+                ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyEmpty();
+    }
+
     @Test
     public void distanceTest() {
         verifier.verifyEmpty();

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -85,10 +85,10 @@ public class SpikyBuildingCheckTest
     }
 
     @Test
-    public void circleBuildingFalggedWithStricterAngleThreshold()
+    public void circleBuildingFlaggedWithStricterAngleThreshold()
     {
         verifier.actual(setup.circleBuilding(), new SpikyBuildingCheck(ConfigurationResolver
-                .inlineConfiguration("{\"SpikyBuildingCheck\":{\"curve.angle.maximum\":3}}")));
+                .inlineConfiguration("{\"SpikyBuildingCheck\":{\"curve.degrees.maximum.single_heading_change\":3.0}}")));
         verifier.verifyExpectedSize(3);
     }
 
@@ -97,8 +97,17 @@ public class SpikyBuildingCheckTest
     {
         verifier.actual(setup.circleBuilding(),
                 new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"SpikyBuildingCheck\":{\"curve.angle.total.minimum\":179}}")));
+                        "{\"SpikyBuildingCheck\":{\"curve.degrees.minimum.total_heading_change\":179.0}}")));
         verifier.verifyExpectedSize(3);
+    }
+
+    @Test
+    public void spikyBuildingNotFlaggedSmallThreshold()
+    {
+        verifier.actual(setup.getSpikyBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"SpikyBuildingCheck\":{\"spiky.angle.maximum\":0.1}}")));
+        verifier.verifyEmpty();
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.checks.validation.areas;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
@@ -81,5 +82,14 @@ public class SpikyBuildingCheckTest
         verifier.actual(setup.circleBuilding(),
                 new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
         verifier.verifyEmpty();
+    }
+
+    @Test
+    public void smallConsecutiveCurves()
+    {
+        verifier.actual(setup.twoShortConsecutiveCurvesBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyExpectedSize(1);
+        verifier.verify(flag -> Assert.assertEquals(2, flag.getPoints().size()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -87,8 +87,9 @@ public class SpikyBuildingCheckTest
     @Test
     public void circleBuildingFlaggedWithStricterAngleThreshold()
     {
-        verifier.actual(setup.circleBuilding(), new SpikyBuildingCheck(ConfigurationResolver
-                .inlineConfiguration("{\"SpikyBuildingCheck\":{\"curve.degrees.maximum.single_heading_change\":3.0}}")));
+        verifier.actual(setup.circleBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"SpikyBuildingCheck\":{\"curve.degrees.maximum.single_heading_change\":3.0}}")));
         verifier.verifyExpectedSize(3);
     }
 
@@ -104,9 +105,8 @@ public class SpikyBuildingCheckTest
     @Test
     public void spikyBuildingNotFlaggedSmallThreshold()
     {
-        verifier.actual(setup.getSpikyBuilding(),
-                new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"SpikyBuildingCheck\":{\"spiky.angle.maximum\":0.1}}")));
+        verifier.actual(setup.getSpikyBuilding(), new SpikyBuildingCheck(ConfigurationResolver
+                .inlineConfiguration("{\"SpikyBuildingCheck\":{\"spiky.angle.maximum\":0.1}}")));
         verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -1,12 +1,9 @@
 package org.openstreetmap.atlas.checks.validation.areas;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
-import org.openstreetmap.atlas.geography.Location;
-import org.openstreetmap.atlas.geography.Segment;
 
 import static org.junit.Assert.*;
 
@@ -54,24 +51,16 @@ public class SpikyBuildingCheckTest
     }
 
     @Test
-    public void distanceTest() {
+    public void badCase() {
+        verifier.actual(setup.badCase(), new SpikyBuildingCheck(
+                ConfigurationResolver.emptyConfiguration()));
         verifier.verifyEmpty();
-        Location start = Location.forString("0,0");
-        Location end = Location.forString("0.5,0.5");
-        Assert.assertEquals(5000000 * Math.sqrt(2), SpikyBuildingCheck.distance(start, end), .001);
     }
 
     @Test
-    public void dotProdTest() {
-        verifier.verifyEmpty();
-        Location start = Location.forString("0,0");
-        Location middle = Location.forString("0.5,0.5");
-        Location end = Location.forString("1,0");
-        Location otherEnd = Location.forString("1,1");
-        Segment a = new Segment(start, middle);
-        Segment b = new Segment(middle, end);
-        Segment c = new Segment(start, end);
-        Assert.assertEquals(0, SpikyBuildingCheck.dotProd(start, middle, end), .0001);
-        Assert.assertEquals(-50000000000000L, SpikyBuildingCheck.dotProd(start, middle, otherEnd), .0001);
+    public void badCase2() {
+        verifier.actual(setup.badCase2(), new SpikyBuildingCheck(
+                ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyExpectedSize(1);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -1,0 +1,68 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Segment;
+
+import static org.junit.Assert.*;
+
+public class SpikyBuildingCheckTest
+{
+    @Rule
+    public SpikyBuildingCheckTestRule setup = new SpikyBuildingCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void findsSpikyBuildings() {
+        verifier.actual(setup.getSpikyBuilding(), new SpikyBuildingCheck(
+                ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void findsSpikyBuildingsRoundNumbers() {
+        verifier.actual(setup.getRoundNumbersSpiky(), new SpikyBuildingCheck(
+                ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyExpectedSize(1);
+    }
+    @Test
+    public void doesNotFindNormalBuilding() {
+        verifier.actual(setup.getNormalBuilding(), new SpikyBuildingCheck(
+                ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyEmpty();
+    }
+
+    @Test
+    public void doesNotFindNormalBuildingRound() {
+        verifier.actual(setup.getNormalRound(), new SpikyBuildingCheck(
+                ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyEmpty();
+    }
+    @Test
+    public void distanceTest() {
+        verifier.verifyEmpty();
+        Location start = Location.forString("0,0");
+        Location end = Location.forString("0.5,0.5");
+        Assert.assertEquals(5000000 * Math.sqrt(2), SpikyBuildingCheck.distance(start, end), .001);
+    }
+
+    @Test
+    public void dotProdTest() {
+        verifier.verifyEmpty();
+        Location start = Location.forString("0,0");
+        Location middle = Location.forString("0.5,0.5");
+        Location end = Location.forString("1,0");
+        Location otherEnd = Location.forString("1,1");
+        Segment a = new Segment(start, middle);
+        Segment b = new Segment(middle, end);
+        Segment c = new Segment(start, end);
+        Assert.assertEquals(0, SpikyBuildingCheck.dotProd(start, middle, end), .0001);
+        Assert.assertEquals(-50000000000000L, SpikyBuildingCheck.dotProd(start, middle, otherEnd), .0001);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -5,8 +5,11 @@ import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
 
-import static org.junit.Assert.*;
-
+/**
+ * Tests for SpikyBuildingCheck
+ *
+ * @author nachtm
+ */
 public class SpikyBuildingCheckTest
 {
     @Rule
@@ -16,51 +19,59 @@ public class SpikyBuildingCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     @Test
-    public void findsSpikyBuildings() {
-        verifier.actual(setup.getSpikyBuilding(), new SpikyBuildingCheck(
-                ConfigurationResolver.emptyConfiguration()));
+    public void findsSpikyBuildings()
+    {
+        verifier.actual(setup.getSpikyBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
         verifier.verifyExpectedSize(1);
     }
 
     @Test
-    public void findsSpikyBuildingsRoundNumbers() {
-        verifier.actual(setup.getRoundNumbersSpiky(), new SpikyBuildingCheck(
-                ConfigurationResolver.emptyConfiguration()));
+    public void findsSpikyBuildingsRoundNumbers()
+    {
+        verifier.actual(setup.getRoundNumbersSpiky(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
         verifier.verifyExpectedSize(1);
     }
+
     @Test
-    public void doesNotFindNormalBuilding() {
-        verifier.actual(setup.getNormalBuilding(), new SpikyBuildingCheck(
-                ConfigurationResolver.emptyConfiguration()));
+    public void doesNotFindNormalBuilding()
+    {
+        verifier.actual(setup.getNormalBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
         verifier.verifyEmpty();
     }
 
     @Test
-    public void doesNotFindNormalBuildingRound() {
-        verifier.actual(setup.getNormalRound(), new SpikyBuildingCheck(
-                ConfigurationResolver.emptyConfiguration()));
+    public void doesNotFindNormalBuildingRound()
+    {
+        verifier.actual(setup.getNormalRound(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
         verifier.verifyEmpty();
     }
 
     // We should ignore edges with only three vertices
     @Test
-    public void ignoresSpikyButSmall() {
-        verifier.actual(setup.getSpikyButSmall(), new SpikyBuildingCheck(
-                ConfigurationResolver.emptyConfiguration()));
+    public void ignoresSpikyButSmall()
+    {
+        verifier.actual(setup.getSpikyButSmall(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
         verifier.verifyEmpty();
     }
 
     @Test
-    public void badCase() {
-        verifier.actual(setup.badCase(), new SpikyBuildingCheck(
-                ConfigurationResolver.emptyConfiguration()));
+    public void badCase()
+    {
+        verifier.actual(setup.badCase(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
         verifier.verifyEmpty();
     }
 
     @Test
-    public void badCase2() {
-        verifier.actual(setup.badCase2(), new SpikyBuildingCheck(
-                ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyExpectedSize(1);
+    public void badCase2()
+    {
+        verifier.actual(setup.badCase2(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -76,6 +76,32 @@ public class SpikyBuildingCheckTest
     }
 
     @Test
+    public void circleBuildingFlaggedWithMorePoints()
+    {
+        verifier.actual(setup.circleBuilding(), new SpikyBuildingCheck(ConfigurationResolver
+                .inlineConfiguration("{\"SpikyBuildingCheck\":{\"curve.points.minimum\":10}}")));
+        verifier.verifyExpectedSize(3);
+
+    }
+
+    @Test
+    public void circleBuildingFalggedWithStricterAngleThreshold()
+    {
+        verifier.actual(setup.circleBuilding(), new SpikyBuildingCheck(ConfigurationResolver
+                .inlineConfiguration("{\"SpikyBuildingCheck\":{\"curve.angle.maximum\":3}}")));
+        verifier.verifyExpectedSize(3);
+    }
+
+    @Test
+    public void circleBuildingFlaggedWithLargerTotalAngleRequirement()
+    {
+        verifier.actual(setup.circleBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"SpikyBuildingCheck\":{\"curve.angle.total.minimum\":179}}")));
+        verifier.verifyExpectedSize(3);
+    }
+
+    @Test
     public void smallConsecutiveCurves()
     {
         verifier.actual(setup.twoShortConsecutiveCurvesBuilding(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -74,4 +74,12 @@ public class SpikyBuildingCheckTest
                 new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
         verifier.verifyEmpty();
     }
+
+    @Test
+    public void circleBuilding()
+    {
+        verifier.actual(setup.circleBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
+        verifier.verifyEmpty();
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -51,15 +51,6 @@ public class SpikyBuildingCheckTest
         verifier.verifyEmpty();
     }
 
-    // We should ignore edges with only three vertices
-    @Test
-    public void ignoresSpikyButSmall()
-    {
-        verifier.actual(setup.getSpikyButSmall(),
-                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyEmpty();
-    }
-
     @Test
     public void badCase()
     {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -20,24 +20,29 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     private static final String ROUND_FIVE = "0.0000005,0.0000020";
 
     @TestAtlas(
-            buildings = @Building(id = "1", outer = @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO_A), @Loc(value=TWO), @Loc(value=THREE)}), tags={"building=yes"})
+            areas = { @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO_A), @Loc(value=TWO), @Loc(value=THREE)}, tags="building=yes")}
     )
     private Atlas spikyBuilding;
 
     @TestAtlas(
-            buildings = @Building(outer = @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO), @Loc(value=FOUR), @Loc(value=THREE)}))
+            areas = { @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO), @Loc(value=FOUR), @Loc(value=THREE)}, tags="building=yes") }
     )
     private Atlas normalBuilding;
 
     @TestAtlas(
-            buildings = @Building(outer = @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value = ROUND_THREE), @Loc(value = ROUND_FOUR), @Loc(value = ROUND_FIVE)}))
+            areas = { @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value = ROUND_THREE), @Loc(value = ROUND_FOUR), @Loc(value = ROUND_FIVE)}, tags="building=yes") }
     )
     private Atlas normalRound;
 
     @TestAtlas(
-            buildings = @Building(outer = @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value=ROUND_TWO), @Loc(value=ROUND_THREE), @Loc(value=ROUND_FOUR), @Loc(value=ROUND_FIVE)}))
+            areas = { @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value=ROUND_TWO), @Loc(value=ROUND_THREE), @Loc(value=ROUND_FOUR), @Loc(value=ROUND_FIVE)}, tags="building=yes") }
     )
     private Atlas roundNumbersSpiky;
+
+    @TestAtlas(
+            areas = { @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value=ROUND_TWO), @Loc(value=ROUND_THREE)}, tags= "building=yes") }
+    )
+    private Atlas spikyButSmall;
 
     public Atlas getSpikyBuilding()
     {
@@ -57,5 +62,10 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     public Atlas getNormalRound()
     {
         return normalRound;
+    }
+
+    public Atlas getSpikyButSmall()
+    {
+        return spikyButSmall;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -1,0 +1,61 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.*;
+
+public class SpikyBuildingCheckTestRule extends CoreTestRule
+{
+    private static final String ONE = "47.616988, -122.356726";
+    private static final String TWO = "47.617031, -122.353797";
+    private static final String TWO_A = "47.617031, -122.350797";
+    private static final String THREE = "47.615671, -122.356";
+    private static final String FOUR = "47.615729, -122.353898";
+
+    private static final String ROUND_ONE = "0.0000005,0.0000005";
+    private static final String ROUND_TWO = "0.0000035,0.0000005";
+    private static final String ROUND_THREE = "0.0000025,0.0000006";
+    private static final String ROUND_FOUR = "0.0000025,0.0000020";
+    private static final String ROUND_FIVE = "0.0000005,0.0000020";
+
+    @TestAtlas(
+            buildings = @Building(id = "1", outer = @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO_A), @Loc(value=TWO), @Loc(value=THREE)}), tags={"building=yes"})
+    )
+    private Atlas spikyBuilding;
+
+    @TestAtlas(
+            buildings = @Building(outer = @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO), @Loc(value=FOUR), @Loc(value=THREE)}))
+    )
+    private Atlas normalBuilding;
+
+    @TestAtlas(
+            buildings = @Building(outer = @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value = ROUND_THREE), @Loc(value = ROUND_FOUR), @Loc(value = ROUND_FIVE)}))
+    )
+    private Atlas normalRound;
+
+    @TestAtlas(
+            buildings = @Building(outer = @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value=ROUND_TWO), @Loc(value=ROUND_THREE), @Loc(value=ROUND_FOUR), @Loc(value=ROUND_FIVE)}))
+    )
+    private Atlas roundNumbersSpiky;
+
+    public Atlas getSpikyBuilding()
+    {
+        return spikyBuilding;
+    }
+
+    public Atlas getNormalBuilding()
+    {
+        return normalBuilding;
+    }
+
+    public Atlas getRoundNumbersSpiky()
+    {
+        return roundNumbersSpiky;
+    }
+
+    public Atlas getNormalRound()
+    {
+        return normalRound;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -3,8 +3,14 @@ package org.openstreetmap.atlas.checks.validation.areas;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
-import org.openstreetmap.atlas.utilities.testing.TestAtlas.*;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 
+/**
+ * SpikyBuildingCheck test atlases
+ *
+ * @author nachtm
+ */
 public class SpikyBuildingCheckTestRule extends CoreTestRule
 {
     private static final String ONE = "47.616988, -122.356726";
@@ -32,40 +38,34 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     private static final String J = "50.4541504, -4.8257998";
     private static final String K = "50.4541645, -4.8259790";
 
-    @TestAtlas(
-            areas = { @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO_A), @Loc(value=TWO), @Loc(value=THREE)}, tags="building=yes")}
-    )
+    @TestAtlas(areas = { @Area(coordinates = { @Loc(value = ONE), @Loc(value = TWO_A),
+            @Loc(value = TWO), @Loc(value = THREE) }, tags = "building=yes") })
     private Atlas spikyBuilding;
 
-    @TestAtlas(
-            areas = { @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO), @Loc(value=FOUR), @Loc(value=THREE)}, tags="building=yes") }
-    )
+    @TestAtlas(areas = { @Area(coordinates = { @Loc(value = ONE), @Loc(value = TWO),
+            @Loc(value = FOUR), @Loc(value = THREE) }, tags = "building=yes") })
     private Atlas normalBuilding;
 
-    @TestAtlas(
-            areas = { @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value = ROUND_THREE), @Loc(value = ROUND_FOUR), @Loc(value = ROUND_FIVE)}, tags="building=yes") }
-    )
+    @TestAtlas(areas = { @Area(coordinates = { @Loc(value = ROUND_ONE), @Loc(value = ROUND_THREE),
+            @Loc(value = ROUND_FOUR), @Loc(value = ROUND_FIVE) }, tags = "building=yes") })
     private Atlas normalRound;
 
-    @TestAtlas(
-            areas = { @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value=ROUND_TWO), @Loc(value=ROUND_THREE), @Loc(value=ROUND_FOUR), @Loc(value=ROUND_FIVE)}, tags="building=yes") }
-    )
+    @TestAtlas(areas = { @Area(coordinates = { @Loc(value = ROUND_ONE), @Loc(value = ROUND_TWO),
+            @Loc(value = ROUND_THREE), @Loc(value = ROUND_FOUR),
+            @Loc(value = ROUND_FIVE) }, tags = "building=yes") })
     private Atlas roundNumbersSpiky;
 
-    @TestAtlas(
-            areas = { @Area(coordinates = {@Loc(value=ROUND_ONE), @Loc(value=ROUND_TWO), @Loc(value=ROUND_THREE)}, tags= "building=yes") }
-    )
+    @TestAtlas(areas = { @Area(coordinates = { @Loc(value = ROUND_ONE), @Loc(value = ROUND_TWO),
+            @Loc(value = ROUND_THREE) }, tags = "building=yes") })
     private Atlas spikyButSmall;
 
-    @TestAtlas(
-            areas = { @Area(id = "1", coordinates = {@Loc(value=A), @Loc(value=B), @Loc(value=C), @Loc(value=D), @Loc(value=E), @Loc(value=F)}, tags="building=yes"),
-               }
-    )
+    @TestAtlas(areas = {
+            @Area(id = "1", coordinates = { @Loc(value = A), @Loc(value = B), @Loc(value = C),
+                    @Loc(value = D), @Loc(value = E), @Loc(value = F) }, tags = "building=yes"), })
     private Atlas badCase;
 
-    @TestAtlas(
-            areas = {  @Area(coordinates = {@Loc(value=G), @Loc(value=H), @Loc(value=I), @Loc(value=J), @Loc(value=K)}, tags="building=yes") }
-    )
+    @TestAtlas(areas = { @Area(coordinates = { @Loc(value = G), @Loc(value = H), @Loc(value = I),
+            @Loc(value = J), @Loc(value = K) }, tags = "building=yes") })
     private Atlas badCase2;
 
     public Atlas getSpikyBuilding()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -19,6 +19,19 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     private static final String ROUND_FOUR = "0.0000025,0.0000020";
     private static final String ROUND_FIVE = "0.0000005,0.0000020";
 
+    private static final String A = "22.5136768, 114.0802380";
+    private static final String B = "22.5136402, 114.0802804";
+    private static final String C = "22.5136130, 114.0802528";
+    private static final String D = "22.5135873, 114.0802267";
+    private static final String E = "22.5135594, 114.0801985";
+    private static final String F = "22.5135961, 114.0801561";
+
+    private static final String G = "50.4542345, -4.8259661";
+    private static final String H = "50.4542210, -4.8257859";
+    private static final String I = "50.4542209, -4.8257867";
+    private static final String J = "50.4541504, -4.8257998";
+    private static final String K = "50.4541645, -4.8259790";
+
     @TestAtlas(
             areas = { @Area(coordinates = {@Loc(value=ONE), @Loc(value=TWO_A), @Loc(value=TWO), @Loc(value=THREE)}, tags="building=yes")}
     )
@@ -44,6 +57,17 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     )
     private Atlas spikyButSmall;
 
+    @TestAtlas(
+            areas = { @Area(id = "1", coordinates = {@Loc(value=A), @Loc(value=B), @Loc(value=C), @Loc(value=D), @Loc(value=E), @Loc(value=F)}, tags="building=yes"),
+               }
+    )
+    private Atlas badCase;
+
+    @TestAtlas(
+            areas = {  @Area(coordinates = {@Loc(value=G), @Loc(value=H), @Loc(value=I), @Loc(value=J), @Loc(value=K)}, tags="building=yes") }
+    )
+    private Atlas badCase2;
+
     public Atlas getSpikyBuilding()
     {
         return spikyBuilding;
@@ -67,5 +91,15 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     public Atlas getSpikyButSmall()
     {
         return spikyButSmall;
+    }
+
+    public Atlas badCase()
+    {
+        return badCase;
+    }
+
+    public Atlas badCase2()
+    {
+        return badCase2;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -48,7 +48,9 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     private static final String S = "1.2799293, 103.8382500";
     private static final String T = "1.2799582, 103.8382024";
     private static final String U = "1.2799679, 103.8381499";
+    private static final String U_PRIME = "1.27996945, 103.838543";
     private static final String V = "1.2799710, 103.8389356";
+    private static final String V_PRIME = "1.27995015, 103.8385928";
 
     @TestAtlas(areas = { @Area(coordinates = { @Loc(value = ONE), @Loc(value = TWO_A),
             @Loc(value = TWO), @Loc(value = THREE) }, tags = "building=yes") })
@@ -94,6 +96,12 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
                     @Loc(value = L) }, tags = "building=yes") })
     private Atlas circleBuilding;
 
+    @TestAtlas(areas = {
+            @Area(id = "1", coordinates = { @Loc(value = S), @Loc(value = T), @Loc(value = U), @Loc(value = U_PRIME),
+                    @Loc(value = V), @Loc(value = V_PRIME), @Loc(value = L), @Loc(value = N)}, tags = "building=yes")
+    })
+    private Atlas twoShortConsecutiveCurvesBuilding;
+
     public Atlas getSpikyBuilding()
     {
         return spikyBuilding;
@@ -132,5 +140,10 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     public Atlas circleBuilding()
     {
         return circleBuilding;
+    }
+
+    public Atlas twoShortConsecutiveCurvesBuilding()
+    {
+        return twoShortConsecutiveCurvesBuilding;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -38,6 +38,18 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     private static final String J = "50.4541504, -4.8257998";
     private static final String K = "50.4541645, -4.8259790";
 
+    private static final String L = "1.2796474, 103.8383986";
+    private static final String M = "1.2796485, 103.8382257";
+    private static final String N = "1.2796800, 103.8382153";
+    private static final String O = "1.2797157, 103.8382624";
+    private static final String P = "1.2797573, 103.8382886";
+    private static final String Q = "1.2798157, 103.8383006";
+    private static final String R = "1.2798743, 103.8382891";
+    private static final String S = "1.2799293, 103.8382500";
+    private static final String T = "1.2799582, 103.8382024";
+    private static final String U = "1.2799679, 103.8381499";
+    private static final String V = "1.2799710, 103.8389356";
+
     @TestAtlas(areas = { @Area(coordinates = { @Loc(value = ONE), @Loc(value = TWO_A),
             @Loc(value = TWO), @Loc(value = THREE) }, tags = "building=yes") })
     private Atlas spikyBuilding;
@@ -67,6 +79,19 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     @TestAtlas(areas = { @Area(coordinates = { @Loc(value = G), @Loc(value = H), @Loc(value = I),
             @Loc(value = J), @Loc(value = K) }, tags = "building=yes") })
     private Atlas badCase2;
+
+    @TestAtlas(areas = {
+            @Area(id = "1", coordinates = { @Loc(value = L), @Loc(value = M), @Loc(value = N),
+                    @Loc(value = O), @Loc(value = P), @Loc(value = Q), @Loc(value = R),
+                    @Loc(value = S), @Loc(value = T), @Loc(value = U),
+                    @Loc(value = V) }, tags = "building=yes"),
+            @Area(id = "2", coordinates = { @Loc(value = P), @Loc(value = Q), @Loc(value = R),
+                    @Loc(value = S), @Loc(value = T), @Loc(value = U), @Loc(value = V),
+                    @Loc(value = L), @Loc(value = M), @Loc(value = N),
+                    @Loc(value = O) }, tags = "building=yes"),
+            @Area(id = "3", coordinates = { @Loc(value = S), @Loc(value = T), @Loc(value = U),
+                    @Loc(value = V), @Loc(value = L) }, tags = "building=yes") })
+    private Atlas circleBuilding;
 
     public Atlas getSpikyBuilding()
     {
@@ -101,5 +126,10 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     public Atlas badCase2()
     {
         return badCase2;
+    }
+
+    public Atlas circleBuilding()
+    {
+        return circleBuilding;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -89,8 +89,9 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
                     @Loc(value = S), @Loc(value = T), @Loc(value = U), @Loc(value = V),
                     @Loc(value = L), @Loc(value = M), @Loc(value = N),
                     @Loc(value = O) }, tags = "building=yes"),
-            @Area(id = "3", coordinates = { @Loc(value = S), @Loc(value = T), @Loc(value = U),
-                    @Loc(value = V), @Loc(value = L) }, tags = "building=yes") })
+            @Area(id = "3", coordinates = { @Loc(value = Q), @Loc(value = R), @Loc(value = S),
+                    @Loc(value = T), @Loc(value = U), @Loc(value = V),
+                    @Loc(value = L) }, tags = "building=yes") })
     private Atlas circleBuilding;
 
     public Atlas getSpikyBuilding()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -69,10 +69,6 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
             @Loc(value = ROUND_FIVE) }, tags = "building=yes") })
     private Atlas roundNumbersSpiky;
 
-    @TestAtlas(areas = { @Area(coordinates = { @Loc(value = ROUND_ONE), @Loc(value = ROUND_TWO),
-            @Loc(value = ROUND_THREE) }, tags = "building=yes") })
-    private Atlas spikyButSmall;
-
     @TestAtlas(areas = {
             @Area(id = "1", coordinates = { @Loc(value = A), @Loc(value = B), @Loc(value = C),
                     @Loc(value = D), @Loc(value = E), @Loc(value = F) }, tags = "building=yes"), })
@@ -96,10 +92,9 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
                     @Loc(value = L) }, tags = "building=yes") })
     private Atlas circleBuilding;
 
-    @TestAtlas(areas = {
-            @Area(id = "1", coordinates = { @Loc(value = S), @Loc(value = T), @Loc(value = U), @Loc(value = U_PRIME),
-                    @Loc(value = V), @Loc(value = V_PRIME), @Loc(value = L), @Loc(value = N)}, tags = "building=yes")
-    })
+    @TestAtlas(areas = { @Area(id = "1", coordinates = { @Loc(value = S), @Loc(value = T),
+            @Loc(value = U), @Loc(value = U_PRIME), @Loc(value = V), @Loc(value = V_PRIME),
+            @Loc(value = L), @Loc(value = N) }, tags = "building=yes") })
     private Atlas twoShortConsecutiveCurvesBuilding;
 
     public Atlas getSpikyBuilding()
@@ -120,11 +115,6 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
     public Atlas getNormalRound()
     {
         return normalRound;
-    }
-
-    public Atlas getSpikyButSmall()
-    {
-        return spikyButSmall;
     }
 
     public Atlas badCase()


### PR DESCRIPTION
### Description:

The purpose of this check is to identify buildings with extremely sharp angles in their geometry. 
These angles, or “spikes” are formed by two or more poly-lines and a peak node. These spikes are often hard to visually inspect as the poly-lines that create them can be very small. Spikes in building 
geometry are almost always errors and should be corrected. They can be inadvertently created in the 
data creation process by incorrectly closing a poly-line to create a polygon.

This check is inspired by [this help.openstreetmap.org thread](https://help.openstreetmap.org/questions/66104/is-there-a-way-to-detect-very-sharp-angles-of-buildings), which includes [this paper](https://drive.google.com/file/d/1MaLdnSnc454xKjn3eL95vDQKeoIW8zGU/view). There are a few differences, since the paper uses the Mercator projection while Atlas does not, but the idea of finding spiky angles in buildings is the same.

This check flags all Atlas objects for which the following criteria are true:
 * The object is a building or a building part
 * The angle created by the intersection of any two line segments within the building's geometry 
 is less than some configurable value.
 * An angle less than 15˚ is not be flagged if it occurs at the beginning or end of a curve 
 within the building's geometry. There are three configurable heuristics to identify curves: the minimum number of points inside of a curve, the maximum difference in heading between two consecutive segments in a curve, and the minimum difference in heading between the start segment and end segment of a curve. That is, any specific point in a curve must have a small change in direction, but the overall curve must change direction. 

### Potential Impact:

Just a new check.

### Unit Test Approach:

Tested a variety of cases, including buildings with curved segments, non-spiky buildings, spiky buildings, a couple of real-world buildings, and buildings with curved segments that don't fit the heuristics (and therefore should be flagged). 

### Test Results:

All tests passing.

