### PR TITLE
MapRoulette Upload Command

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/commands/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/MapRouletteUploadCommand.java
@@ -6,7 +6,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -115,7 +117,14 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                     {
                         reader.lines().forEach(line -> {
                             final Task task = gson.fromJson(line, Task.class);
-                            this.getMapRouletteClient().addTask(this.getChallenge(task.getChallengeName(), instructions), task);
+                            try
+                            {
+                                this.addTask(this.getChallenge(task.getChallengeName(), instructions), task);
+                            }
+                            catch (URISyntaxException | UnsupportedEncodingException error)
+                            {
+                                error.printStackTrace();
+                            }
                         });
                     }
                     catch (final IOException error)
@@ -123,7 +132,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                         error.printStackTrace();
                     }
                 }
-                this.getMapRouletteClient().uploadTasks();
+                this.uploadTasks();
             }
             catch (final IOException error)
             {

--- a/src/main/java/org/openstreetmap/atlas/checks/commands/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/MapRouletteUploadCommand.java
@@ -1,0 +1,167 @@
+package org.openstreetmap.atlas.checks.commands;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.checks.maproulette.MapRouletteCommand;
+import org.openstreetmap.atlas.checks.maproulette.MapRouletteConfiguration;
+import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
+import org.openstreetmap.atlas.checks.maproulette.data.Task;
+import org.openstreetmap.atlas.checks.maproulette.serializer.ChallengeDeserializer;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
+import org.openstreetmap.atlas.utilities.conversion.StringConverter;
+import org.openstreetmap.atlas.utilities.runtime.Command;
+import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Given a directory of log files created by atlas-checks, upload those files to MapRoulette.
+ *
+ * @author nachtm
+ */
+public class MapRouletteUploadCommand extends MapRouletteCommand
+{
+    private class TaskDeserializer implements JsonDeserializer<Task>
+    {
+        private String projectName;
+
+        TaskDeserializer(final String projectName)
+        {
+            this.projectName = projectName;
+        }
+
+        @Override public Task deserialize(final JsonElement json, final Type typeOfT,
+                final JsonDeserializationContext context) throws JsonParseException
+        {
+            final JsonObject full = json.getAsJsonObject();
+            final JsonObject properties = full.get("properties").getAsJsonObject();
+            final String challengeName = properties.get("generator").getAsString();
+            final String instruction = properties.get("instructions").getAsString();
+            final String taskID = properties.get("id").getAsString();
+            final JsonArray geojson = full.get("features").getAsJsonArray();
+            final Task result = new Task();
+            //challenge name
+            result.setChallengeName(challengeName);
+            //geojson
+            result.setGeoJson(Optional.of(geojson));
+            //instruction
+            result.setInstruction(instruction);
+            // points should be set at the same time as the geojson
+            //project name
+            result.setProjectName(projectName);
+            //task id
+            result.setTaskIdentifier(taskID);
+            return result;
+        }
+    }
+
+    private static final Switch<File> INPUT_DIRECTORY = new Command.Switch<>("logfiles",
+            "blah blah blah", File::new, Optionality.REQUIRED);
+    private static final Switch<File> CONFIG_LOCATION = new Command.Switch<>("config",
+            "blah", File::new, Optionality.REQUIRED);
+    private static final String PARAMETER_CHALLENGE = "challenge";
+    private static final Logger logger = LoggerFactory.getLogger(MapRouletteUploadCommand.class);
+    private final Map<String, Challenge> checkNameChallengeMap;
+
+    @Override public SwitchList switches()
+    {
+        return super.switches().with(INPUT_DIRECTORY, CONFIG_LOCATION);
+    }
+    // see RunnableCheck.uploadTasks()
+
+    public MapRouletteUploadCommand()
+    {
+        super();
+        this.checkNameChallengeMap = new HashMap<>();
+    }
+
+    @Override protected void execute(final CommandMap commandMap, final MapRouletteConfiguration configuration)
+    {
+        // read in the directory
+        final File[] files = ((File) commandMap.get(INPUT_DIRECTORY)).listFiles();
+        if (files == null)
+        {
+            logger.error("No files found for the given directory.");
+        }
+        else
+        {
+            try
+            {
+                final Gson gson = new GsonBuilder().registerTypeAdapter(Task.class, new TaskDeserializer(configuration.getProjectName())).create();
+                final Configuration instructions = this
+                        .loadConfiguration(commandMap, CONFIG_LOCATION);
+                for (final File logFile : files)
+                {
+                    try (BufferedReader reader = new BufferedReader(new FileReader(logFile.getPath())))
+                    {
+                        reader.lines().forEach(line -> {
+                            final Task task = gson.fromJson(line, Task.class);
+                            this.getMapRouletteClient().addTask(this.getChallenge(task.getChallengeName(), instructions), task);
+                        });
+                    }
+                    catch (final IOException error)
+                    {
+                        error.printStackTrace();
+                    }
+                }
+                this.getMapRouletteClient().uploadTasks();
+            }
+            catch (final IOException error)
+            {
+                error.printStackTrace();
+            }
+        }
+    }
+
+    // TODO empty challenge config?
+    private Challenge readChallenge(final Configuration configuration, final String checkName)
+    {
+        final Map<String, String> challengeMap = configuration.get(getChallengeParameter(checkName), Collections.EMPTY_MAP).value();
+        final Gson gson = new GsonBuilder().disableHtmlEscaping()
+                .registerTypeAdapter(Challenge.class, new ChallengeDeserializer()).create();
+        final Challenge result = gson.fromJson(gson.toJson(challengeMap), Challenge.class);
+        result.setName(checkName);
+        return result;
+    }
+
+    private Configuration loadConfiguration(final CommandMap map, final Switch<File> configSwitch) throws IOException
+    {
+        return new StandardConfiguration(new InputStreamResource(new FileInputStream((File) map.get(configSwitch))));
+    }
+
+    private String getChallengeParameter(final String checkName)
+    {
+        return checkName + "." + PARAMETER_CHALLENGE;
+    }
+
+    // loads a challenge from our store if it exists, otherwise reads from configuration
+    private Challenge getChallenge(final String checkName, final Configuration fallbackConfiguration)
+    {
+        return this.checkNameChallengeMap.computeIfAbsent(checkName, name -> readChallenge(fallbackConfiguration, name));
+    }
+
+    public static void main(final String[] args)
+    {
+        new MapRouletteUploadCommand().run(args);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/TaskDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/TaskDeserializer.java
@@ -1,0 +1,111 @@
+package org.openstreetmap.atlas.checks.maproulette.serializer;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.openstreetmap.atlas.checks.maproulette.data.Task;
+import org.openstreetmap.atlas.geography.Latitude;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Longitude;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Deserializes a line from a line-delimited geojson log file into into a Task object, given a
+ * particular project name.
+ *
+ * @author nachtm
+ */
+public class TaskDeserializer implements JsonDeserializer<Task>
+{
+    private static final String PROPERTIES = "properties";
+    private static final String GENERATOR = "generator";
+    private static final String INSTRUCTIONS = "instructions";
+    private static final String ID = "id";
+    private static final String FEATURES = "features";
+    private static final String GEOMETRY = "geometry";
+    private static final String COORDINATES = "coordinates";
+    private String projectName;
+
+    public TaskDeserializer(final String projectName)
+    {
+        this.projectName = projectName;
+    }
+
+    @Override
+    public Task deserialize(final JsonElement json, final Type typeOfT,
+            final JsonDeserializationContext context) throws JsonParseException
+    {
+        final JsonObject full = json.getAsJsonObject();
+        final JsonObject properties = full.get(PROPERTIES).getAsJsonObject();
+        final String challengeName = properties.get(GENERATOR).getAsString();
+        final String instruction = properties.get(INSTRUCTIONS).getAsString();
+        final String taskID = properties.get(ID).getAsString();
+        final JsonArray geojson = full.get(FEATURES).getAsJsonArray();
+        final Task result = new Task();
+        result.setChallengeName(challengeName);
+        result.setPoints(this.getPointsFromGeojson(geojson));
+        result.setGeoJson(Optional.of(this.filterOutPointsFromGeojson(geojson)));
+        result.setInstruction(instruction);
+        result.setProjectName(projectName);
+        result.setTaskIdentifier(taskID);
+        return result;
+    }
+
+    /**
+     * Returns a {@link Set} of {@link Location}s gathered from feature.geometry.coordinates for
+     * each feature in features which does not have a properties field.
+     * 
+     * @param features
+     *            a {@link JsonArray} of geojson features.
+     * @return a {@link Set} of {@link Location}s which were generated from task.addPoints() (and
+     *         therefore have no properties of their own).
+     */
+    private Set<Location> getPointsFromGeojson(final JsonArray features)
+    {
+        return this.objectStream(features).filter(feature -> !feature.has(PROPERTIES))
+                .map(feature -> feature.get(GEOMETRY).getAsJsonObject().get(COORDINATES)
+                        .getAsJsonArray())
+                .map(longlatArray -> new Location(
+                        Latitude.degrees(longlatArray.get(1).getAsDouble()),
+                        Longitude.degrees(longlatArray.get(0).getAsDouble())))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * The opposite of getPointsFromGeojson -- get all geojson features which do contain a
+     * properties field from a {@link JsonArray}.
+     * 
+     * @param features
+     *            a {@link JsonArray} of geojson features
+     * @return a JsonArray containing all features which were added to a task through
+     *         task.setGeojson() and therefore should have properties.
+     */
+    private JsonArray filterOutPointsFromGeojson(final JsonArray features)
+    {
+        return this.objectStream(features).filter(feature -> feature.has(PROPERTIES))
+                .collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
+    }
+
+    /**
+     * Stream all of the {@link JsonObject}s in a {@link JsonArray}.
+     * 
+     * @param features
+     *            a {@link JsonArray} containing only {@link JsonObject}s
+     * @return a {@link Stream} containing all {@link JsonObject}s inside features.
+     */
+    private Stream<JsonObject> objectStream(final JsonArray features)
+    {
+        return StreamSupport.stream(features.spliterator(), false)
+                .map(JsonElement::getAsJsonObject);
+    }
+}


### PR DESCRIPTION
### Description:

This is a new command to facilitate batch uploading of .log files to MapRoulette. More specifically, running `MapRouletteUploadCommand` with the following parameters
```
-logfiles=/path/to/a/folder/of/log/files/
-config=/path/to/a/configuration/file.json
-maproulette=server:port:projectName:apiKey
```
will take that `logfile` folder and create a project titled `projectName` at the given instance of MapRoulette. Inside of that project, there will be one challenge per check present in the log files inside the `logfile` folder.

### Potential Impact:

None -- this is a new command. 

### Unit Test Approach:

Tried uploading log files from checks that I had previously run, including those without challenge parameters in `configuration.json`, and points showed up as markers on MapRoulette.

### Test Results:

Files were uploaded successfully. Checks without challenge parameters were uploaded with empty descriptions. 