### PR TITLE
AreasWithHighwayTagsCheck enhancements

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -26,7 +26,7 @@
     }
   },
   "AreasWithHighwayTagCheck":{
-    "tag.filters":"highway->!pedestrian&area->!yes",
+    "tag.filters":"highway->*&area->yes",
     "challenge":{
       "description":"A Highway should never be tagged as an area, all these tasks involve highways that have been.",
       "blurb":"Highways should not be tagged as Areas.",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheck.java
@@ -29,13 +29,11 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 public class AreasWithHighwayTagCheck extends BaseCheck<Long>
 {
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            "The way with OSM ID {0,number,#} has a highway value which does not match the OSM standard.",
+            "The way with OSM ID {0,number,#} has a highway value of {1}, which should not have an area=yes tag. Consider changing this to highway={2}.",
             "The way with OSM ID {0,number,#} has a highway value of {1}, which should not have an area=yes tag.");
     private static final long serialVersionUID = 3638306611072651348L;
     private static final EnumSet<HighwayTag> VALID_HIGHWAY_TAGS = EnumSet.of(HighwayTag.SERVICES,
             HighwayTag.SERVICE, HighwayTag.REST_AREA, HighwayTag.PEDESTRIAN, HighwayTag.PLATFORM);
-    private static final EnumSet<HighwayTag> NON_STANDARD_HIGHWAY_TAGS = EnumSet
-            .of(HighwayTag.FOOTWAY, HighwayTag.BUS_STOP, HighwayTag.PATH, HighwayTag.STEPS);
 
     public AreasWithHighwayTagCheck(final Configuration configuration)
     {
@@ -59,9 +57,10 @@ public class AreasWithHighwayTagCheck extends BaseCheck<Long>
                 .filter(tag -> isUnacceptableAreaHighwayTagCombination(object, tag)).map(tag ->
                 {
                     final String instruction;
-                    if (this.isNotOsmStandard(tag))
+                    if (tag.equals(HighwayTag.FOOTWAY))
                     {
-                        instruction = this.getLocalizedInstruction(0, object.getOsmIdentifier());
+                        instruction = this.getLocalizedInstruction(0, object.getOsmIdentifier(),
+                                tag, HighwayTag.PEDESTRIAN);
                     }
                     else
                     {
@@ -108,10 +107,5 @@ public class AreasWithHighwayTagCheck extends BaseCheck<Long>
     {
         return !VALID_HIGHWAY_TAGS.contains(tag)
                 && Validators.isOfType(object, AreaTag.class, AreaTag.YES);
-    }
-
-    private boolean isNotOsmStandard(final HighwayTag tag)
-    {
-        return NON_STANDARD_HIGHWAY_TAGS.contains(tag);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheck.java
@@ -32,9 +32,9 @@ public class AreasWithHighwayTagCheck extends BaseCheck<Long>
             "The way with OSM ID {0,number,#} has a highway value which does not match the OSM standard.",
             "The way with OSM ID {0,number,#} has a highway value of {1}, which should not have an area=yes tag.");
     private static final long serialVersionUID = 3638306611072651348L;
-    private static final EnumSet<HighwayTag> validHighwayTags = EnumSet.of(HighwayTag.SERVICES,
+    private static final EnumSet<HighwayTag> VALID_HIGHWAY_TAGS = EnumSet.of(HighwayTag.SERVICES,
             HighwayTag.SERVICE, HighwayTag.REST_AREA, HighwayTag.PEDESTRIAN, HighwayTag.PLATFORM);
-    private static final EnumSet<HighwayTag> notToStandardHighwayTags = EnumSet
+    private static final EnumSet<HighwayTag> NON_STANDARD_HIGHWAY_TAGS = EnumSet
             .of(HighwayTag.FOOTWAY, HighwayTag.BUS_STOP, HighwayTag.PATH, HighwayTag.STEPS);
 
     public AreasWithHighwayTagCheck(final Configuration configuration)
@@ -55,7 +55,7 @@ public class AreasWithHighwayTagCheck extends BaseCheck<Long>
         {
             return object.getTag(HighwayTag.KEY)
                     .map(tagString -> HighwayTag.valueOf(tagString.toUpperCase()))
-                    // If the tag isn't one of the validHighwayTags, we want to flag it.
+                    // If the tag isn't one of the VALID_HIGHWAY_TAGS, we want to flag it.
                     .filter(tag -> isUnacceptableAreaHighwayTagCombination(object, tag)).map(tag ->
                     {
                         final String instruction;
@@ -101,21 +101,24 @@ public class AreasWithHighwayTagCheck extends BaseCheck<Long>
     }
 
     /**
-     * An object is not allowed to have a highway tag that is not in validHighwayTags if it also has
-     * an area=yes tag
-     * @param object the object in question
-     * @param tag the object's highway tag
+     * An object is not allowed to have a highway tag that is not in VALID_HIGHWAY_TAGS if it also
+     * has an area=yes tag
+     * 
+     * @param object
+     *            the object in question
+     * @param tag
+     *            the object's highway tag
      * @return true if the object has an invalid highway tag and an area=yes tag
      */
     static boolean isUnacceptableAreaHighwayTagCombination(final AtlasObject object,
             final HighwayTag tag)
     {
-        return !validHighwayTags.contains(tag)
+        return !VALID_HIGHWAY_TAGS.contains(tag)
                 && Validators.isOfType(object, AreaTag.class, AreaTag.YES);
     }
 
     private boolean isNotOsmStandard(final HighwayTag tag)
     {
-        return notToStandardHighwayTags.contains(tag);
+        return NON_STANDARD_HIGHWAY_TAGS.contains(tag);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckWalker.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckWalker.java
@@ -1,0 +1,29 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.walker.EdgeWalker;
+
+/**
+ * Simple walker to grab all connected edges which have a bad combination of area=yes and some
+ * highway tag.
+ *
+ * @author nachtm
+ */
+public class AreasWithHighwayTagCheckWalker extends EdgeWalker
+{
+
+    private static final Predicate<Edge> isBadEdgeWithAreaTag = edge -> AreasWithHighwayTagCheck
+            .isUnacceptableAreaHighwayTagCombination(edge, edge.highwayTag());
+
+    private static final Function<Edge, Stream<Edge>> getNeighborStream = edge -> edge
+            .connectedEdges().stream();
+
+    public AreasWithHighwayTagCheckWalker(final Edge startingEdge)
+    {
+        super(startingEdge, isBadEdgeWithAreaTag, getNeighborStream);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckWalker.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckWalker.java
@@ -16,14 +16,14 @@ import org.openstreetmap.atlas.geography.atlas.walker.EdgeWalker;
 public class AreasWithHighwayTagCheckWalker extends EdgeWalker
 {
 
-    private static final Predicate<Edge> isBadEdgeWithAreaTag = edge -> AreasWithHighwayTagCheck
+    private static final Predicate<Edge> IS_BAD_EDGE_WITH_AREA_TAG = edge -> AreasWithHighwayTagCheck
             .isUnacceptableAreaHighwayTagCombination(edge, edge.highwayTag());
 
-    private static final Function<Edge, Stream<Edge>> getNeighborStream = edge -> edge
+    private static final Function<Edge, Stream<Edge>> GET_NEIGHBOR_STREAM = edge -> edge
             .connectedEdges().stream();
 
     public AreasWithHighwayTagCheckWalker(final Edge startingEdge)
     {
-        super(startingEdge, isBadEdgeWithAreaTag, getNeighborStream);
+        super(startingEdge, IS_BAD_EDGE_WITH_AREA_TAG, GET_NEIGHBOR_STREAM);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTest.java
@@ -94,4 +94,12 @@ public class AreasWithHighwayTagCheckTest
         this.verifier.actual(this.setup.validAreaHighwayPrimaryNoAreaTag(), check);
         this.verifier.verifyEmpty();
     }
+
+    @Test
+    public void connectedEdgesBadTags()
+    {
+        this.verifier.actual(this.setup.connectedEdgesBadTags(), check);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTest.java
@@ -15,7 +15,7 @@ public class AreasWithHighwayTagCheckTest
 
     private final AreasWithHighwayTagCheck check = new AreasWithHighwayTagCheck(
             ConfigurationResolver.inlineConfiguration(
-                    "{\"AreasWithHighwayTagCheck\":{\"tags.filter\":\"highway->!pedestrian&area->!yes\"}}"));
+                    "{\"AreasWithHighwayTagCheck\":{\"tags.filter\":\"highway->*&area->yes\"}}"));
 
     @Rule
     public AreasWithHighwayTagCheckTestRule setup = new AreasWithHighwayTagCheckTestRule();
@@ -58,5 +58,40 @@ public class AreasWithHighwayTagCheckTest
         this.verifier.verify(flag -> Assert.assertEquals(flag.getInstructions(),
                 String.format("Area with OSM ID %s is missing area tag.",
                         AreasWithHighwayTagCheckTestRule.INVALID_AREA_ID)));
+    }
+
+    @Test
+    public void validAreaHighwayPlatform()
+    {
+        this.verifier.actual(this.setup.validAreaHighwayPlatform(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void invalidEdgeHighwaySecondary()
+    {
+        this.verifier.actual(this.setup.invalidEdgeHighwaySecondary(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void validEdgeHighwayService()
+    {
+        this.verifier.actual(this.setup.validEdgeHighwayService(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void validEdgeNoAreaTag()
+    {
+        this.verifier.actual(this.setup.validEdgeNoAreaTag(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void validAreaHighwayPrimaryNoAreaTag()
+    {
+        this.verifier.actual(this.setup.validAreaHighwayPrimaryNoAreaTag(), check);
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTestRule.java
@@ -97,6 +97,17 @@ public class AreasWithHighwayTagCheckTestRule extends CoreTestRule
                     @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=primary" }) })
     private Atlas validAreaHighwayPrimaryNoAreaTag;
 
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = AREA_LOCATION_ONE)),
+            @Node(coordinates = @Loc(value = AREA_LOCATION_TWO)),
+            @Node(coordinates = @Loc(value = AREA_LOCATION_THREE)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = AREA_LOCATION_ONE),
+                            @Loc(value = AREA_LOCATION_TWO) }, tags = { "area=yes",
+                                    "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = AREA_LOCATION_TWO),
+                            @Loc(value = AREA_LOCATION_THREE) }, tags = { "area=yes",
+                                    "highway=primary" }) })
+    private Atlas connectedEdgesBadTags;
+
     public Atlas areaNoHighwayTagAtlas()
     {
         return this.areaNoHighwayTagAtlas;
@@ -145,6 +156,11 @@ public class AreasWithHighwayTagCheckTestRule extends CoreTestRule
     public Atlas validAreaHighwayPrimaryNoAreaTag()
     {
         return validAreaHighwayPrimaryNoAreaTag;
+    }
+
+    public Atlas connectedEdgesBadTags()
+    {
+        return connectedEdgesBadTags;
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTestRule.java
@@ -4,7 +4,9 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 
 /**
  * @author daniel-baah
@@ -25,33 +27,75 @@ public class AreasWithHighwayTagCheckTestRule extends CoreTestRule
                     @Loc(value = AREA_LOCATION_ONE) }, tags = { "random=tag" }) })
     private Atlas areaNoHighwayTagAtlas;
 
-    // Valid area with highway=pedestrian tag
+    // Don't flag areas with area=yes tag and highway tag in validHighwayTags.
+    // This shouldn't ever happen in the wild, since the default atlas filter only allows areas
+    // without highway tags or highway=platform.
     @TestAtlas(areas = { @Area(coordinates = { @Loc(value = AREA_LOCATION_ONE),
             @Loc(value = AREA_LOCATION_TWO), @Loc(value = AREA_LOCATION_THREE),
             @Loc(value = AREA_LOCATION_FOUR),
             @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=pedestrian", "area=yes" }) })
     private Atlas validHighwayPedestrianTagAtlas;
 
-    // Area with invalid highway tag
+    // Flag area with area=yes tag and highway tag not in validHighwayTags
+    // Same as validHighwayPedestrianTagAtlas, this should not appear in the wild.
     @TestAtlas(areas = {
             @Area(coordinates = { @Loc(value = AREA_LOCATION_ONE), @Loc(value = AREA_LOCATION_TWO),
                     @Loc(value = AREA_LOCATION_THREE), @Loc(value = AREA_LOCATION_FOUR),
-                    @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=primary" }) })
+                    @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=primary", "area=yes" }) })
     private Atlas invalidAreaHighwayPrimaryTagAtlas;
 
     // Area with invalid highway=footway tag
+    // As above, this should not appear in the wild.
     @TestAtlas(areas = {
             @Area(coordinates = { @Loc(value = AREA_LOCATION_ONE), @Loc(value = AREA_LOCATION_TWO),
                     @Loc(value = AREA_LOCATION_THREE), @Loc(value = AREA_LOCATION_FOUR),
-                    @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=footway" }) })
+                    @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=footway", "area=yes" }) })
     private Atlas invalidAreaHighwayFootwayTagAtlas;
 
     // Pedestrian highway without area=yes tag
+    // As above, this should not appear in the wild.
     @TestAtlas(areas = { @Area(id = INVALID_AREA_ID, coordinates = {
             @Loc(value = AREA_LOCATION_ONE), @Loc(value = AREA_LOCATION_TWO),
             @Loc(value = AREA_LOCATION_THREE), @Loc(value = AREA_LOCATION_FOUR),
             @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=pedestrian" }) })
     private Atlas invalidHighwayPedestrianNoAreaTagAtlas;
+
+    // Area with highway=platform tag, which is legitimate.
+    @TestAtlas(areas = {
+            @Area(coordinates = { @Loc(value = AREA_LOCATION_ONE), @Loc(value = AREA_LOCATION_TWO),
+                    @Loc(value = AREA_LOCATION_THREE), @Loc(value = AREA_LOCATION_FOUR),
+                    @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=platform", "area=yes" }) })
+    private Atlas validAreaHighwayPlatform;
+
+    // Flag edge with area=yes tag and highway tag not in validHighwayTags
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = AREA_LOCATION_ONE)),
+            @Node(coordinates = @Loc(value = AREA_LOCATION_TWO)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = AREA_LOCATION_ONE), @Loc(value = AREA_LOCATION_TWO) }, tags = {
+                            "area=yes", "highway=secondary" }) })
+    private Atlas invalidEdgeHighwaySecondary;
+
+    // Don't flag edge with area=yes tag and highway tag in validHighwayTags
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = AREA_LOCATION_ONE)),
+            @Node(coordinates = @Loc(value = AREA_LOCATION_TWO)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = AREA_LOCATION_ONE), @Loc(value = AREA_LOCATION_TWO) }, tags = {
+                            "area=yes", "highway=service" }) })
+    private Atlas validEdgeHighwayService;
+
+    // Don't flag edge without area=yes tag
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = AREA_LOCATION_ONE)),
+            @Node(coordinates = @Loc(value = AREA_LOCATION_TWO)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = AREA_LOCATION_ONE),
+                            @Loc(value = AREA_LOCATION_TWO) }, tags = { "highway=secondary" }) })
+    private Atlas validEdgeNoAreaTag;
+
+    // Don't flag areas without area=yes tag, regardless of highway tags.
+    // The way that would generate this area would actually be ingested as an edge in a real-world
+    // scenario.
+    @TestAtlas(areas = {
+            @Area(coordinates = { @Loc(value = AREA_LOCATION_ONE), @Loc(value = AREA_LOCATION_TWO),
+                    @Loc(value = AREA_LOCATION_THREE), @Loc(value = AREA_LOCATION_FOUR),
+                    @Loc(value = AREA_LOCATION_ONE) }, tags = { "highway=primary" }) })
+    private Atlas validAreaHighwayPrimaryNoAreaTag;
 
     public Atlas areaNoHighwayTagAtlas()
     {
@@ -76,6 +120,31 @@ public class AreasWithHighwayTagCheckTestRule extends CoreTestRule
     public Atlas invalidHighwayPedestrianNoAreaTagAtlas()
     {
         return this.invalidHighwayPedestrianNoAreaTagAtlas;
+    }
+
+    public Atlas validAreaHighwayPlatform()
+    {
+        return this.validAreaHighwayPlatform;
+    }
+
+    public Atlas invalidEdgeHighwaySecondary()
+    {
+        return invalidEdgeHighwaySecondary;
+    }
+
+    public Atlas validEdgeHighwayService()
+    {
+        return validEdgeHighwayService;
+    }
+
+    public Atlas validEdgeNoAreaTag()
+    {
+        return validEdgeNoAreaTag;
+    }
+
+    public Atlas validAreaHighwayPrimaryNoAreaTag()
+    {
+        return validAreaHighwayPrimaryNoAreaTag;
     }
 
 }


### PR DESCRIPTION
### Description:

This is a series of enhancements to AreasWithHighwayTagsCheck. 
 - Previously, only areas were being checked. This missed out on a large number of OSM ways that were tagged with area=yes and some invalid highway value. 
 - In addition, there are some highway tags that are valid in conjunction with area=yes that were previously being flagged. Those are no longer flagged.
 - Finally, instead of just flagging the particular edge in question, we gather all connected edges with improper combinations of area and highway tags. This makes the output of this check easier to understand for people who are familiar with OSM but not Atlas. This may also reduce the flag count in some cases, since connected improperly tagged edges will be flagged as a single unit now.

In short, the new logic is as follows: for any area or edge, if that object has an area=yes tag and a highway tag that is not one of `{services, service, rest area, pedestrian, platform}`, flag it and all connected edges that share a similar problem.

### Potential Impact:

Changed flag counts for AreasWithHighwayTags.

### Unit Test Approach:

Added unit tests to cover edges and a couple of new area cases.

### Test Results:

All tests passing.
