### PR TITLE
Remove ChallengePriority.NONE

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -59,8 +59,8 @@ public class Challenge implements Serializable
     public Challenge(final String name, final String description, final String blurb,
             final String instruction, final ChallengeDifficulty difficulty, final String tags)
     {
-        this(name, description, blurb, instruction, difficulty, ChallengePriority.NONE, null, null,
-                null, tags);
+        this(name, description, blurb, instruction, difficulty, ChallengePriority.MEDIUM, null,
+                null, null, tags);
     }
 
     public Challenge(final String name, final String description, final String blurb,

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -59,7 +59,7 @@ public class Challenge implements Serializable
     public Challenge(final String name, final String description, final String blurb,
             final String instruction, final ChallengeDifficulty difficulty, final String tags)
     {
-        this(name, description, blurb, instruction, difficulty, ChallengePriority.MEDIUM, null,
+        this(name, description, blurb, instruction, difficulty, ChallengePriority.LOW, null,
                 null, null, tags);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengePriority.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengePriority.java
@@ -5,7 +5,6 @@ package org.openstreetmap.atlas.checks.maproulette.data;
  */
 public enum ChallengePriority
 {
-    NONE(-1),
     HIGH(0),
     MEDIUM(1),
     LOW(2);
@@ -21,7 +20,7 @@ public enum ChallengePriority
                 return challengePriority;
             }
         }
-        return ChallengePriority.NONE;
+        return ChallengePriority.MEDIUM;
     }
 
     ChallengePriority(final int value)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengePriority.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengePriority.java
@@ -5,6 +5,7 @@ package org.openstreetmap.atlas.checks.maproulette.data;
  */
 public enum ChallengePriority
 {
+    @Deprecated
     NONE(-1),
     HIGH(0),
     MEDIUM(1),

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengePriority.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengePriority.java
@@ -5,6 +5,7 @@ package org.openstreetmap.atlas.checks.maproulette.data;
  */
 public enum ChallengePriority
 {
+    NONE(-1),
     HIGH(0),
     MEDIUM(1),
     LOW(2);
@@ -20,7 +21,7 @@ public enum ChallengePriority
                 return challengePriority;
             }
         }
-        return ChallengePriority.MEDIUM;
+        return ChallengePriority.LOW;
     }
 
     ChallengePriority(final int value)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/ChallengeDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/ChallengeDeserializer.java
@@ -51,8 +51,8 @@ public class ChallengeDeserializer implements JsonDeserializer<Challenge>
         }
         catch (final IllegalArgumentException e)
         {
-            logger.trace("Failed to read priority value from Challenge JSON, defaulting to NONE");
-            priority = ChallengePriority.NONE;
+            logger.trace("Failed to read priority value from Challenge JSON, defaulting to MEDIUM");
+            priority = ChallengePriority.MEDIUM;
         }
 
         return new Challenge(this.getStringValue(challengeObject, Challenge.KEY_NAME, ""),

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/ChallengeDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/ChallengeDeserializer.java
@@ -51,7 +51,7 @@ public class ChallengeDeserializer implements JsonDeserializer<Challenge>
         }
         catch (final IllegalArgumentException e)
         {
-            logger.trace("Failed to read priority value from Challenge JSON, defaulting to MEDIUM");
+            logger.trace("Failed to read priority value from Challenge JSON, defaulting to LOW");
             priority = ChallengePriority.LOW;
         }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/ChallengeDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/ChallengeDeserializer.java
@@ -52,7 +52,7 @@ public class ChallengeDeserializer implements JsonDeserializer<Challenge>
         catch (final IllegalArgumentException e)
         {
             logger.trace("Failed to read priority value from Challenge JSON, defaulting to MEDIUM");
-            priority = ChallengePriority.MEDIUM;
+            priority = ChallengePriority.LOW;
         }
 
         return new Challenge(this.getStringValue(challengeObject, Challenge.KEY_NAME, ""),

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
@@ -33,7 +33,7 @@ public class ChallengeSerializationTest
         Assert.assertEquals(BLURB, deserializedChallenge.getBlurb());
         Assert.assertEquals(INSTRUCTION, deserializedChallenge.getInstruction());
         Assert.assertEquals(ChallengeDifficulty.NORMAL, deserializedChallenge.getDifficulty());
-        Assert.assertEquals(ChallengePriority.NONE, deserializedChallenge.getDefaultPriority());
+        Assert.assertEquals(ChallengePriority.MEDIUM, deserializedChallenge.getDefaultPriority());
         Assert.assertNull(deserializedChallenge.getHighPriorityRule());
         Assert.assertNull(deserializedChallenge.getMediumPriorityRule());
         Assert.assertNull(deserializedChallenge.getLowPriorityRule());

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
@@ -33,7 +33,7 @@ public class ChallengeSerializationTest
         Assert.assertEquals(BLURB, deserializedChallenge.getBlurb());
         Assert.assertEquals(INSTRUCTION, deserializedChallenge.getInstruction());
         Assert.assertEquals(ChallengeDifficulty.NORMAL, deserializedChallenge.getDifficulty());
-        Assert.assertEquals(ChallengePriority.MEDIUM, deserializedChallenge.getDefaultPriority());
+        Assert.assertEquals(ChallengePriority.LOW, deserializedChallenge.getDefaultPriority());
         Assert.assertNull(deserializedChallenge.getHighPriorityRule());
         Assert.assertNull(deserializedChallenge.getMediumPriorityRule());
         Assert.assertNull(deserializedChallenge.getLowPriorityRule());

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
@@ -33,7 +33,7 @@ public class ChallengeSerializationTest
         Assert.assertEquals(BLURB, deserializedChallenge.getBlurb());
         Assert.assertEquals(INSTRUCTION, deserializedChallenge.getInstruction());
         Assert.assertEquals(ChallengeDifficulty.NORMAL, deserializedChallenge.getDifficulty());
-        Assert.assertEquals(ChallengePriority.LOW, deserializedChallenge.getDefaultPriority());
+        Assert.assertEquals(ChallengePriority.NONE, deserializedChallenge.getDefaultPriority());
         Assert.assertNull(deserializedChallenge.getHighPriorityRule());
         Assert.assertNull(deserializedChallenge.getMediumPriorityRule());
         Assert.assertNull(deserializedChallenge.getLowPriorityRule());
@@ -104,6 +104,24 @@ public class ChallengeSerializationTest
         Assert.assertEquals(deserializedJson.get("description"), rawJson.get("description"));
         Assert.assertEquals(deserializedJson.get("blurb"), rawJson.get("blurb"));
         Assert.assertEquals(deserializedJson.get("instruction"), rawJson.get("instruction"));
+    }
+
+    /**
+     * Tests that a challenge with no defaultPriority specified gets loaded as defaultPriority=LOW.
+     */
+    @Test
+    public void serializationNoDefaultPrioritySpecified()
+    {
+        final Challenge deserializedChallenge = this.getChallenge("challenges/testChallenge4.json");
+
+        Assert.assertEquals(DESCRIPTION, deserializedChallenge.getDescription());
+        Assert.assertEquals(BLURB, deserializedChallenge.getBlurb());
+        Assert.assertEquals(INSTRUCTION, deserializedChallenge.getInstruction());
+        Assert.assertEquals(ChallengeDifficulty.NORMAL, deserializedChallenge.getDifficulty());
+        Assert.assertEquals(ChallengePriority.LOW, deserializedChallenge.getDefaultPriority());
+        Assert.assertNull(deserializedChallenge.getHighPriorityRule());
+        Assert.assertNull(deserializedChallenge.getMediumPriorityRule());
+        Assert.assertNull(deserializedChallenge.getLowPriorityRule());
     }
 
     /**

--- a/src/test/resources/challenges/testChallenge4.json
+++ b/src/test/resources/challenges/testChallenge4.json
@@ -1,0 +1,7 @@
+{
+  "name": "TEST_CHALLENGE",
+  "description": "DESCRIPTION",
+  "blurb": "BLURB",
+  "instruction": "INSTRUCTION",
+  "difficulty": "NORMAL"
+}


### PR DESCRIPTION
### Description:

There is no corresponding value to ChallengePriority.NONE on the MapRoulette side. Trying to upload a challenge with ChallengePriority.NONE, or its integer value (-1) leads to poorly visualized checks. Compare the result of an upload with ChallengePriority.NONE:
<img width="1670" alt="screen shot 2018-12-13 at 11 39 21 am" src="https://user-images.githubusercontent.com/12106730/49963050-ce6f0a80-fecb-11e8-8aaa-26e0649ecaf5.png">
to the exact same run, but with ChallengePriority.MEDIUM:
<img width="1666" alt="screen shot 2018-12-13 at 11 38 52 am" src="https://user-images.githubusercontent.com/12106730/49963083-de86ea00-fecb-11e8-8c3a-0ba4eead233c.png">

In addition, when uploading tasks directly through the MapRoulette UI, you cannot select a default priority of none:
![screen shot 2018-12-13 at 11 49 47 am](https://user-images.githubusercontent.com/12106730/49963581-3eca5b80-fecd-11e8-9c25-1f75bbea8cf5.png)

So, this PR removes the NONE value from the enum, and updates the deserializer to default to LOW.

### Potential Impact:

Any library using ChallengePriority.NONE will have to update those values to be something that matches the MapRoulette options.

### Unit Test Approach:

Updated a unit test to expect a default of ChallengePriority.LOW. Also ran atlas-checks with maproulette uploads before and after.

### Test Results:

All tests passing. Much better results on maproulette on this branch compared to dev. 

