### PR TITLE
Add createFlag with multiple instructions

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -340,6 +340,12 @@ public abstract class BaseCheck<T> implements Check, Serializable
                 Collections.singletonList(instruction), points);
     }
 
+    protected CheckFlag createFlag(final Set<AtlasObject> objects, final List<String> instructions,
+            final List<Location> points)
+    {
+        return new CheckFlag(this.getTaskIdentifier(objects), objects, instructions, points);
+    }
+
     protected abstract Optional<CheckFlag> flag(AtlasObject object);
 
     /**


### PR DESCRIPTION
### Description:

This adds an overridden `createFlag` that takes in a list of instructions. All other `createFlag` functions only take in a single instruction, forcing users to manually concatenate multiple instructions together instead of using the `addInstructions` method already built-in to `CheckFlag`.

One note -- if I can change `CheckFlag`'s constructor to take in an `Iterable<String>` instead of a `List<String>`, then this function could take an iterable, which would be more general and easier to use. 

### Potential Impact:

Only a new method to use.

### Unit Test Approach:

There are no unit tests for `BaseCheck` at the moment -- adding them would probably be worthwhile. In the meantime, I tested this by modifying a couple of checks to use this constructor and running them on small datasets.

### Test Results:

All results look valid.

