### PR TITLE
OneMemberRelationCheck - Update tags.filter

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -223,6 +223,7 @@
     }
   },
   "OneMemberRelationCheck": {
+    "relations.skip": ["type->person,multipolygon"],
     "challenge": {
       "description": "Tasks containing relations with only one member.",
       "blurb": "One Member Relations",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -223,7 +223,7 @@
     }
   },
   "OneMemberRelationCheck": {
-    "relations.skip": ["type->person,multipolygon"],
+    "tag.filter": "type->!person&type->!multipolygon",
     "challenge": {
       "description": "Tasks containing relations with only one member.",
       "blurb": "One Member Relations",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -223,7 +223,7 @@
     }
   },
   "OneMemberRelationCheck": {
-    "tag.filter": "type->!person&type->!multipolygon",
+    "tags.filter": "type->!person&type->!multipolygon",
     "challenge": {
       "description": "Tasks containing relations with only one member.",
       "blurb": "One Member Relations",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -2,10 +2,12 @@ package org.openstreetmap.atlas.checks.validation.relations;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
@@ -13,25 +15,27 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
  * This check flags {@link Relation}s which contain only one member.
  *
  * @author savannahostrowski
+ * @author nachtm
  */
-public class OneMemberRelationCheck extends BaseCheck
+public class OneMemberRelationCheck extends BaseCheck<Long>
 {
     public static final String OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only "
             + "one member.";
 
-    public static final String MULTIPOLYGON_OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only "
-            + "one member. Multi-polygon relations need multiple polygons.";
-
     public static final String MEMBER_RELATION_INSTRUCTIONS = "This relation, {0,number,#}, contains only relation {1,number,#}.";
 
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(OMR_INSTRUCTIONS,
-            MULTIPOLYGON_OMR_INSTRUCTIONS, MEMBER_RELATION_INSTRUCTIONS);
+            MEMBER_RELATION_INSTRUCTIONS);
+    private static final List<String> DEFAULT_RELATIONS_TO_SKIP = Collections
+            .singletonList("type->person,multipolygon");
+    private List<TaggableFilter> relationsToSkip;
 
     @Override
     protected List<String> getFallbackInstructions()
@@ -42,12 +46,16 @@ public class OneMemberRelationCheck extends BaseCheck
     public OneMemberRelationCheck(final Configuration configuration)
     {
         super(configuration);
+        this.relationsToSkip = this.configurationValue(configuration, "relations.skip",
+                DEFAULT_RELATIONS_TO_SKIP, strings -> strings.stream()
+                        .map(TaggableFilter::forDefinition).collect(Collectors.toList()));
     }
 
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Relation;
+        return object instanceof Relation
+                && this.relationsToSkip.stream().noneMatch(filter -> filter.test(object));
     }
 
     @Override
@@ -62,14 +70,8 @@ public class OneMemberRelationCheck extends BaseCheck
             if (members.get(0).getEntity().getType().equals(ItemType.RELATION))
             {
                 return Optional.of(createFlag(getRelationMembers((Relation) object),
-                        this.getLocalizedInstruction(2, relation.getOsmIdentifier(),
+                        this.getLocalizedInstruction(1, relation.getOsmIdentifier(),
                                 members.get(0).getEntity().getOsmIdentifier())));
-            }
-            // If the relation is a multi-polygon,
-            if (relation.isMultiPolygon())
-            {
-                return Optional.of(createFlag(getRelationMembers((Relation) object),
-                        this.getLocalizedInstruction(1, relation.getOsmIdentifier())));
             }
             return Optional.of(createFlag(getRelationMembers((Relation) object),
                     this.getLocalizedInstruction(0, relation.getOsmIdentifier())));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -10,11 +10,15 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  * Tests for {@link OneMemberRelationCheck}
  *
  * @author savannahostrowski
+ * @author nachtm
  */
 public class OneMemberRelationCheckTest
 {
     private static final OneMemberRelationCheck check = new OneMemberRelationCheck(
             ConfigurationResolver.emptyConfiguration());
+    private static final OneMemberRelationCheck noPeopleOrMultipolygons = new OneMemberRelationCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"OneMemberRelationCheck\":{\"tags.filter\":\"type->!person&type->!multipolygon\"}}"));
 
     @Rule
     public OneMemberRelationCheckTestRule setup = new OneMemberRelationCheckTestRule();
@@ -63,6 +67,14 @@ public class OneMemberRelationCheckTest
         this.verifier.actual(this.setup.oneMemberRelationRelationAtlas(), check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(flag.getFlaggedObjects().size(), 3));
+    }
+
+    @Test
+    public void testOneMemberRelationMultipolygonConfig()
+    {
+        this.verifier.actual(this.setup.getOneMemberRelationMultipolygonOuter(),
+                noPeopleOrMultipolygons);
+        this.verifier.verifyEmpty();
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -10,16 +10,11 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  * Tests for {@link OneMemberRelationCheck}
  *
  * @author savannahostrowski
- * @author nachtm
  */
 public class OneMemberRelationCheckTest
 {
     private static final OneMemberRelationCheck check = new OneMemberRelationCheck(
             ConfigurationResolver.emptyConfiguration());
-
-    private static final OneMemberRelationCheck checkWithMultipolygons = new OneMemberRelationCheck(
-            ConfigurationResolver.inlineConfiguration(
-                    "{\"OneMemberRelationCheck\":{\"relations.skip\":[\"type->person\"]}}"));
 
     @Rule
     public OneMemberRelationCheckTestRule setup = new OneMemberRelationCheckTestRule();
@@ -45,20 +40,20 @@ public class OneMemberRelationCheckTest
     public void testOneMemberRelationMultipolygonInner()
     {
         this.verifier.actual(this.setup.getOneMemberRelationMultipolygonInner(), check);
-        this.verifier.verifyEmpty();
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
     public void testOneMemberRelationMultipolygonOuter()
     {
         this.verifier.actual(this.setup.getOneMemberRelationMultipolygonOuter(), check);
-        this.verifier.verifyEmpty();
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
     public void testValidRelationMultipolygon()
     {
-        this.verifier.actual(this.setup.getValidRelationMultipolygon(), checkWithMultipolygons);
+        this.verifier.actual(this.setup.getValidRelationMultipolygon(), check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -68,22 +63,6 @@ public class OneMemberRelationCheckTest
         this.verifier.actual(this.setup.oneMemberRelationRelationAtlas(), check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(flag.getFlaggedObjects().size(), 3));
-    }
-
-    @Test
-    public void testOneMemberRelationMultipolygonInnerCustomConfiguration()
-    {
-        this.verifier.actual(this.setup.getOneMemberRelationMultipolygonInner(),
-                checkWithMultipolygons);
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void testOneMemberRelationMultipolygonOuterCustomConfiguration()
-    {
-        this.verifier.actual(this.setup.getOneMemberRelationMultipolygonInner(),
-                checkWithMultipolygons);
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -10,11 +10,16 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  * Tests for {@link OneMemberRelationCheck}
  *
  * @author savannahostrowski
+ * @author nachtm
  */
 public class OneMemberRelationCheckTest
 {
     private static final OneMemberRelationCheck check = new OneMemberRelationCheck(
             ConfigurationResolver.emptyConfiguration());
+
+    private static final OneMemberRelationCheck checkWithMultipolygons = new OneMemberRelationCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"OneMemberRelationCheck\":{\"relations.skip\":[\"type->person\"]}}"));
 
     @Rule
     public OneMemberRelationCheckTestRule setup = new OneMemberRelationCheckTestRule();
@@ -40,20 +45,20 @@ public class OneMemberRelationCheckTest
     public void testOneMemberRelationMultipolygonInner()
     {
         this.verifier.actual(this.setup.getOneMemberRelationMultipolygonInner(), check);
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verifyEmpty();
     }
 
     @Test
     public void testOneMemberRelationMultipolygonOuter()
     {
         this.verifier.actual(this.setup.getOneMemberRelationMultipolygonOuter(), check);
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verifyEmpty();
     }
 
     @Test
     public void testValidRelationMultipolygon()
     {
-        this.verifier.actual(this.setup.getValidRelationMultipolygon(), check);
+        this.verifier.actual(this.setup.getValidRelationMultipolygon(), checkWithMultipolygons);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -63,6 +68,22 @@ public class OneMemberRelationCheckTest
         this.verifier.actual(this.setup.oneMemberRelationRelationAtlas(), check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(flag.getFlaggedObjects().size(), 3));
+    }
+
+    @Test
+    public void testOneMemberRelationMultipolygonInnerCustomConfiguration()
+    {
+        this.verifier.actual(this.setup.getOneMemberRelationMultipolygonInner(),
+                checkWithMultipolygons);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void testOneMemberRelationMultipolygonOuterCustomConfiguration()
+    {
+        this.verifier.actual(this.setup.getOneMemberRelationMultipolygonInner(),
+                checkWithMultipolygons);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
 }


### PR DESCRIPTION
### Description:

This blacklists two types of relations from OneMemberRelationCheck:
1. `type=multipolygon` relations are allowed to have one member. This is common practice in the OSM community and flagging these is not productive.
2. `type=person` relations are very low-importance and not worth reviewing/editing.

### Potential Impact:

Slight drop in the number of flags generated by `OneMemberRelation`.

### Unit Test Approach:

Added a unit test for the current tags.filter value.

### Test Results:

All tests passing.
