### PR TITLE
MapRouletteUploadCommand: Handle gzipped files 

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/commands/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/MapRouletteUploadCommand.java
@@ -46,6 +46,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             Optionality.OPTIONAL, "config/configuration.json");
     private static final String PARAMETER_CHALLENGE = "challenge";
     private static final String LOG_EXTENSION = "log";
+    private static final String ZIPPED_LOG_EXTENSION = ".log.gz";
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteUploadCommand.class);
     private final Map<String, Challenge> checkNameChallengeMap;
 
@@ -104,13 +105,17 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
 
     /**
      * Determine whether or not this file is something we can handle, and classify it accordingly.
-     * @param logFile any file
+     * 
+     * @param logFile
+     *            any file
      * @return if this file is something this command can handle, the appropriate HandledFileType
-     * enum value; otherwise, an empty optional.
+     *         enum value; otherwise, an empty optional.
      */
     private Optional<HandledFileType> maybeGetHandledType(final File logFile)
     {
-        if (logFile.getName().endsWith(".log.gz"))
+        // Note that technically the true extension is just .gz, so we can't use the same method as
+        // below.
+        if (logFile.getName().endsWith(ZIPPED_LOG_EXTENSION))
         {
             return Optional.of(HandledFileType.ZIPPED_LOG);
         }
@@ -123,21 +128,26 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
 
     /**
      * Read a file that we know we should be able to handle
-     * @param inputFile Some file with a valid, appropriate extension.
-     * @param fileType The type of file that inputFile is
+     * 
+     * @param inputFile
+     *            Some file with a valid, appropriate extension.
+     * @param fileType
+     *            The type of file that inputFile is
      * @return a BufferedReader to read inputFile
-     * @throws IOException if the file is not found or is poorly formatted, given its extension.
-     *  For example, if this file is gzipped and something goes wrong in the unzipping process, it
-     *  might throw an error
+     * @throws IOException
+     *             if the file is not found or is poorly formatted, given its extension. For
+     *             example, if this file is gzipped and something goes wrong in the unzipping
+     *             process, it might throw an error
      */
-    private BufferedReader getReader(final File inputFile, final HandledFileType fileType) throws
-            IOException
+    private BufferedReader getReader(final File inputFile, final HandledFileType fileType)
+            throws IOException
     {
         if (fileType == HandledFileType.LOG)
         {
             return new BufferedReader(new FileReader(inputFile.getPath()));
         }
-        return new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(inputFile.getPath()))));
+        return new BufferedReader(new InputStreamReader(
+                new GZIPInputStream(new FileInputStream(inputFile.getPath()))));
     }
 
     /**


### PR DESCRIPTION
### Description:

Previously, log files that were .gzipped were skipped by MapRouletteUploadCommand. Users that wanted to upload zipped files to MapRoulette would have to manually unzip them, which could be tedious. 

This PR gives MapRouletteUploadCommand the capability to handle `.log.gz` files on its own.

### Potential Impact:

None -- just new capabilities.

### Unit Test Approach:

Tried uploading gzipped files and non-zipped files.

### Test Results:

Given the following directory,
<img width="624" alt="image" src="https://user-images.githubusercontent.com/12106730/54565636-059dfd80-498c-11e9-8dd8-02efd6f0a3d0.png">
 
running with the following params
<img width="770" alt="image" src="https://user-images.githubusercontent.com/12106730/54565840-8b21ad80-498c-11e9-8aca-c57aaca58c3f.png">

successfully shows up in MapRoulette, with all tasks present:
<img width="914" alt="image" src="https://user-images.githubusercontent.com/12106730/54565893-a7bde580-498c-11e9-905b-97f59ad7e28b.png">




